### PR TITLE
Move MatchedFrameList submessage to defs

### DIFF
--- a/control/animation.proto
+++ b/control/animation.proto
@@ -31,10 +31,6 @@ message StartAnimation {
     map<sfixed32, MatchedFrameList> matched_frames = 10;
 }
 
-message MatchedFrameList {
-    repeated float frame_numbers = 1;
-}
-
 // START_ANIMATION_ACK
 // Response for START_ANIMATION
 message StartAnimationAck {

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -168,3 +168,7 @@ message CatalogImageBounds {
     string y_column_name = 2;
     ImageBounds image_bounds = 3;
 }
+
+message MatchedFrameList {
+    repeated float frame_numbers = 1;
+}


### PR DESCRIPTION
This makes it possible to categorise it correctly in the autogenerated documentation -- so that it will appear in the correct section with the other submessages, and will be coloured correctly.