### PR TITLE
Fix the stokes concatenation documents

### DIFF
--- a/control/concat_stokes_files.proto
+++ b/control/concat_stokes_files.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 package CARTA;
 
-import "defs.proto";
 import "enums.proto";
 import "open_file.proto";
 

--- a/docs/src/enums.rst.txt
+++ b/docs/src/enums.rst.txt
@@ -491,13 +491,13 @@ Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blo
      - 
    * - :carta:refc:`SPECTRAL_LINE_RESPONSE`
      - 68
-     -
+     - 
    * - :carta:refc:`CONCAT_STOKES_FILES`
      - 69
-     -
+     - 
    * - :carta:refc:`CONCAT_STOKES_FILES_ACK`
      - 70
-     -
+     - 
 
 .. carta:class:: carta-sub filefeatureflags
 
@@ -964,7 +964,6 @@ Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blo
      - 18
      - 
 
-
 .. carta:class:: carta-sub stokestype
 
 .. _stokestype:
@@ -986,16 +985,17 @@ Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blo
      - Description
    * - STOKES_TYPE_NONE
      - 0
-     -
+     - 
    * - I
      - 1
-     -
+     - 
    * - Q
      - 2
-     -
+     - 
    * - U
      - 3
-     -
+     - 
    * - V
      - 4
-     -
+     - 
+

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -379,6 +379,74 @@ Instructs the backend to close a file with a given file ID
      - 
      - Which "file" slot to close
 
+.. carta:class:: carta-f2b concatstokesfiles
+
+.. _concatstokesfiles:
+
+ConcatStokesFiles
+~~~~~~~~~~~~~~~~~
+
+Source file: `control/concat_stokes_files.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/control/concat_stokes_files.proto>`_
+
+CONCAT_STOKES_FILES:
+Requests to concatenate individual stokes images as one and open it.
+Backend responds with :carta:refc:`CONCAT_STOKES_FILES_ACK`
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - stokes_files
+     - :carta:refc:`StokesFile`
+     - repeated
+     - Stokes files to be concatenated
+   * - file_id
+     - sfixed32
+     - 
+     - File ID for the concatenate image
+   * - render_mode
+     - :carta:refc:`RenderMode`
+     - 
+     - The render mode to use. Additional modes will be added in subsequent versions.
+
+.. carta:class:: carta-b2f concatstokesfilesack
+
+.. _concatstokesfilesack:
+
+ConcatStokesFilesAck
+~~~~~~~~~~~~~~~~~~~~
+
+Source file: `control/concat_stokes_files.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/control/concat_stokes_files.proto>`_
+
+
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - success
+     - bool
+     - 
+     - Concatenation is successful or not
+   * - message
+     - string
+     - 
+     - Error message if not successful
+   * - open_file_ack
+     - :carta:refc:`OpenFileAck`
+     - 
+     - Open file acknowledgement for the concatenate file
+
 .. carta:class:: carta-b2f contourimagedata
 
 .. _contourimagedata:
@@ -823,11 +891,11 @@ Source file: `control/resume_session.proto <https://github.com/CARTAvis/carta-pr
    * - contour_settings
      - :carta:refc:`SetContourParameters`
      - 
-     -
+     - 
    * - stokes_files
      - :carta:refc:`StokesFile`
      - repeated
-     -
+     - 
 
 .. carta:class:: carta-f2b importregion
 
@@ -2517,6 +2585,43 @@ Response for :carta:refc:`START_ANIMATION`
      - 
      - The animation ID of the new animation
 
+.. carta:class:: carta-f2b stokesfile
+
+.. _stokesfile:
+
+StokesFile
+~~~~~~~~~~
+
+Source file: `control/concat_stokes_files.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/control/concat_stokes_files.proto>`_
+
+
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - directory
+     - string
+     - 
+     - Required directory name
+   * - file
+     - string
+     - 
+     - Required file name
+   * - hdu
+     - string
+     - 
+     - Which HDU to load (if applicable). If left blank, the first HDU will be used
+   * - stokes_type
+     - :carta:refc:`StokesType`
+     - 
+     - Stokes type
+
 .. carta:class:: carta-f2b stopanimation
 
 .. _stopanimation:
@@ -2621,111 +2726,3 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - 
      - Run-length encodings of NaN values. These values are used to restore the NaN values after decompression.
 
-
-.. carta:class:: carta-f2b stokesfile
-
-.. _stokesfile:
-
-StokesFile
-~~~~~~~~~~
-
-Source file: `control/concat_stokes_files.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/control/concat_stokes_files.proto>`_
-
-
-
-.. list-table::
-   :widths: 20 20 20 40
-   :header-rows: 1
-   :class: proto
-
-   * - Field
-     - Type
-     - Label
-     - Description
-   * - directory
-     - string
-     -
-     - Required directory name
-   * - file
-     - string
-     -
-     - Required file name
-   * - hdu
-     - string
-     -
-     - Which HDU to load (if applicable). If left blank, the first HDU will be used
-   * - stokes_type
-     - :carta:refc:`StokesType`
-     -
-     - The stokes type of this file
-
-
-.. carta:class:: carta-f2b concatstokesfiles
-
-.. _concatstokesfiles:
-
-ConcatStokesFiles
-~~~~~~~~~~~~~~~~~
-
-Source file: `control/concat_stokes_files.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/control/concat_stokes_files.proto>`_
-
-CONCAT_STOKES_FILES:
-Requests the concatenating of stokes files.
-Backend responds with :carta:refc:`CONCAT_STOKES_FILES_ACK`
-
-.. list-table::
-   :widths: 20 20 20 40
-   :header-rows: 1
-   :class: proto
-
-   * - Field
-     - Type
-     - Label
-     - Description
-   * - stokes_files
-     - :carta:refc:`StokesFile`
-     - repeated
-     - Stokes files to be concatenated
-   * - file_id
-     - sfixed32
-     -
-     - File ID for the concatenate image
-   * - render_mode
-     - :carta:refc:`RenderMode`
-     -
-     - The render mode to use. Additional modes will be added in subsequent versions.
-
-
-.. carta:class:: carta-b2f concatstokesfilesack
-
-.. _concatstokesfilesack:
-
-ConcatStokesFilesAck
-~~~~~~~~~~~~~~~~~~~~
-
-Source file: `control/concat_stokes_files.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/control/concat_stokes_files.proto>`_
-
-CONCAT_STOKES_FILES_ACK
-Response for :carta:refc:`CONCAT_STOKES_FILES`. Also supplies file information
-
-.. list-table::
-   :widths: 20 20 20 40
-   :header-rows: 1
-   :class: proto
-
-   * - Field
-     - Type
-     - Label
-     - Description
-   * - success
-     - bool
-     -
-     - Concatenation is successful or not
-   * - message
-     - string
-     -
-     - Error message if not successful
-   * - open_file_ack
-     - :carta:refc:`OpenFileAck`
-     -
-     - Open file acknowledgement for the concatenate file

--- a/request/save_file.proto
+++ b/request/save_file.proto
@@ -7,9 +7,12 @@ message SaveFile {
     sfixed32 file_id = 1;
     string output_file_directory = 2;
     string output_file_name = 3;
+    // The format of a new image file
     FileType output_file_type = 4;
     sfixed32 region_id = 5;
+    // Set image channels: [start, end, stride]
     repeated sfixed32 channels = 6;
+    // Set image stokes: [start, end, stride]
     repeated sfixed32 stokes = 7;
     bool keep_degenerate = 8;
 }

--- a/shared/enums.proto
+++ b/shared/enums.proto
@@ -161,6 +161,7 @@ enum ServerFeatureFlags {
     SZ_COMPRESSION = 1;
     HEVC_COMPRESSION = 2;
     NVENC_COMPRESSION = 4;
+    // Disables write requests, including saving files, exporting regions, and writing preferences and layouts files.
     READ_ONLY = 8;
     USER_PREFERENCES = 16;
     USER_LAYOUTS = 32;


### PR DESCRIPTION
Fix the stokes concatenation documents. Remove the `import "defs.proto"` from the `concat_stokes_files.proto`. Add some comments in the `enums.proto` and `save_file.proto`. This PR should be merged before #48 in order to let it easier to be reviewed.