### PR TITLE
Add return_path field to scripting request

### DIFF
--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -137,3 +137,6 @@
    * - ``23.1.0``
      - 23/07/21
      - Added :carta:ref:`SplataloguePing` and :carta:ref:`SplataloguePong` messages.
+   * - ``23.1.1``
+     - 29/07/21
+     - Added ``return_path`` to :carta:ref:`ScriptingRequest` message.

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -3,7 +3,7 @@ CARTA Interface Control Document
 
 :Date: 23 July 2021
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 23.1.0
+:Version: 23.1.1
 :ICD Version Integer: 23
 :CARTA Target: Version 3.0
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1932,10 +1932,10 @@ Source file: `request/scripting.proto <https://github.com/CARTAvis/carta-protobu
      - bool
      - 
      - flag indicating whether the frontend should execute this asynchronously, or only return once the call is complete
-   * - response_field
+   * - return_path
      - string
      - 
-     - optional string indicating which field of the response to return. If this is empty, the entire response will be returned.
+     - optional string indicating the path of the response sub-object to return. If this is empty, the entire response will be returned.
 
 .. carta:class:: carta-b2f scriptingresponse
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1927,11 +1927,15 @@ Source file: `request/scripting.proto <https://github.com/CARTAvis/carta-protobu
    * - parameters
      - string
      - 
-     - JSON array of paramters. e.g. '["viridis"]'
+     - JSON array of parameters. e.g. '["viridis"]'
    * - async
      - bool
      - 
      - flag indicating whether the frontend should execute this asynchronously, or only return once the call is complete
+   * - response_field
+     - string
+     - 
+     - optional string indicating which field of the response to return. If this is empty, the entire response will be returned.
 
 .. carta:class:: carta-b2f scriptingresponse
 

--- a/request/scripting.proto
+++ b/request/scripting.proto
@@ -2,16 +2,18 @@ syntax = "proto3";
 package CARTA;
 
 message ScriptingRequest {
-    // Used to connect a single scripting request to its response
-    sfixed32 scripting_request_id = 1;
-    // the path of the target object. e.g. activeFrame.renderConfig
-    string target = 2;
-    // the name of the function to call. e.g. setColorMap
-    string action = 3;
-    // JSON array of paramters. e.g. '["viridis"]'
-    string parameters = 4;
-    // flag indicating whether the frontend should execute this asynchronously, or only return once the call is complete
-    bool async = 5;
+  // Used to connect a single scripting request to its response
+  sfixed32 scripting_request_id = 1;
+  // the path of the target object. e.g. activeFrame.renderConfig
+  string target = 2;
+  // the name of the function to call. e.g. setColorMap
+  string action = 3;
+  // JSON array of parameters. e.g. '["viridis"]'
+  string parameters = 4;
+  // flag indicating whether the frontend should execute this asynchronously, or only return once the call is complete
+  bool async = 5;
+  // optional string indicating which field of the response to return. If this is empty, the entire response will be returned.
+  string response_field = 6;
 }
 
 message ScriptingResponse {

--- a/request/scripting.proto
+++ b/request/scripting.proto
@@ -12,8 +12,8 @@ message ScriptingRequest {
   string parameters = 4;
   // flag indicating whether the frontend should execute this asynchronously, or only return once the call is complete
   bool async = 5;
-  // optional string indicating which field of the response to return. If this is empty, the entire response will be returned.
-  string response_field = 6;
+  // optional string indicating the path of the response sub-object to return. If this is empty, the entire response will be returned.
+  string return_path = 6;
 }
 
 message ScriptingResponse {


### PR DESCRIPTION
Fixes a bug in the scripting interface by allowing the wrapper to request a subset of a called action's return value (which can be serialized correctly). Companion to PRs in the frontend, wrapper, carta-scripting-grpc and backend code.