### PR TITLE
platform_strings field added to register viewer ack

### DIFF
--- a/control/register_viewer.proto
+++ b/control/register_viewer.proto
@@ -39,4 +39,6 @@ message RegisterViewerAck {
     map<string, string> user_layouts = 7;
     // The server's scripting gRPC port, if it is enabled
     fixed32 grpc_port = 8;
+    // Map of server-generated platform information strings
+    map<string, string> platform_strings = 9;
 }

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -143,3 +143,6 @@
    * - ``24.0.0``
      - 30/07/21
      - Added the stokes to :carta:ref:`SetStatsRequirements`, :carta:ref:`HistogramConfig`, and :carta:ref:`RegionHistogramData` messages. Removed the channel from :carta:ref:`Histogram`.
+   * - ``24.1.0``
+     - 12/10/21
+     - Added ``platform_strings`` to :carta:ref:`RegisterViewerAck` message.

--- a/docs/src/enums.rst.txt
+++ b/docs/src/enums.rst.txt
@@ -1007,7 +1007,7 @@ Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blo
 .. _polarizationtype:
 
 PolarizationType
-~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/enums.proto>`_
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,9 +1,9 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 23 July 2021
+:Date: 12 Oct 2021
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 24.0.0
+:Version: 24.1.0
 :ICD Version Integer: 24
 :CARTA Target: Version 3.0
 


### PR DESCRIPTION
Adds `platform_strings` map to `RegisterViewerAck` for telemetry purposes. Companion PR of https://github.com/CARTAvis/carta-backend/pull/936