### PR TITLE
Modify the ContourImageData message

### DIFF
--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -147,6 +147,9 @@ Changelog
    * - ``24.1.0``
      - 12/10/21
      - Added ``platform_strings`` to :carta:ref:`RegisterViewerAck` message.
+   * - ``24.1.1``
+     - 30/10/21
+     - Added ``is_long_task`` to :carta:ref:`ContourImageData` message.
 
 Versioning
 ----------

--- a/docs/src/enums.rst.txt
+++ b/docs/src/enums.rst.txt
@@ -733,6 +733,65 @@ Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blo
      - 2
      - 
 
+.. carta:class:: carta-sub polarizationtype
+
+.. _polarizationtype:
+
+PolarizationType
+~~~~~~~~~~~~~~~~
+
+Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/enums.proto>`_
+
+polarization parameters including the Stokes parameters, circular correlations, and linear correlations (the Stokes axis defined by the FITS standard)
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 1
+   :class: proto
+
+   * - Name
+     - Number
+     - Description
+   * - POLARIZATION_TYPE_NONE
+     - 0
+     - 
+   * - I
+     - 1
+     - 
+   * - Q
+     - 2
+     - 
+   * - U
+     - 3
+     - 
+   * - V
+     - 4
+     - 
+   * - RR
+     - 5
+     - 
+   * - LL
+     - 6
+     - 
+   * - RL
+     - 7
+     - 
+   * - LR
+     - 8
+     - 
+   * - XX
+     - 9
+     - 
+   * - YY
+     - 10
+     - 
+   * - XY
+     - 11
+     - 
+   * - YX
+     - 12
+     - 
+
 .. carta:class:: carta-sub regiontype
 
 .. _regiontype:
@@ -1000,64 +1059,5 @@ Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blo
      - 
    * - MaxPosf
      - 18
-     - 
-
-.. carta:class:: carta-sub polarizationtype
-
-.. _polarizationtype:
-
-PolarizationType
-~~~~~~~~~~~~~~~~
-
-Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/enums.proto>`_
-
-polarization parameters including the Stokes parameters, circular correlations, and linear correlations (the Stokes axis defined by the FITS standard)
-
-.. list-table::
-   :widths: 33 33 33
-   :header-rows: 1
-   :class: proto
-
-   * - Name
-     - Number
-     - Description
-   * - POLARIZATION_TYPE_NONE
-     - 0
-     - 
-   * - I
-     - 1
-     - 
-   * - Q
-     - 2
-     - 
-   * - U
-     - 3
-     - 
-   * - V
-     - 4
-     - 
-   * - RR
-     - 5
-     - 
-   * - LL
-     - 6
-     - 
-   * - RL
-     - 7
-     - 
-   * - LR
-     - 8
-     - 
-   * - XX
-     - 9
-     - 
-   * - YY
-     - 10
-     - 
-   * - XY
-     - 11
-     - 
-   * - YX
-     - 12
      - 
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -500,6 +500,10 @@ Data for an image rendered in contour mode.
      - double
      - 
      - Progress of the contour sets being sent. If this is zero, the message is assumed to contain the entire contour sets
+   * - is_long_task
+     - bool
+     - 
+     - Bool variable is true if the estimated process time exceeds 1 second
 
 .. carta:class:: carta-b2f contourset
 
@@ -1699,6 +1703,10 @@ Informs the frontend whether the session was correctly.
      - fixed32
      - 
      - The server's scripting gRPC port, if it is enabled
+   * - platform_strings
+     - map<key: string, value: string>
+     - repeated
+     - Map of server-generated platform information strings
 
 .. carta:class:: carta-f2b removeregion
 

--- a/stream/contour_image.proto
+++ b/stream/contour_image.proto
@@ -22,6 +22,8 @@ message ContourImageData {
     repeated ContourSet contour_sets = 6;
     // Progress of the contour sets being sent. If this is zero, the message is assumed to contain the entire contour sets
     double progress = 7;
+    // Bool variable is true if the estimated process time exceeds 1 second
+    bool is_long_task = 8;
 }
 
 message ContourSet {


### PR DESCRIPTION
It is to fit the frontend requirement in the frontend [PR 1636](https://github.com/CARTAvis/carta-frontend/pull/1636). A new bool variable `is_long_task` is added to the contour data message. `is_long_task=true` if the estimated time of the contour process is greater than 1 second. It decides whether to show the contour progress bar in the frontend. The `.txt` files are also modified by regenerating them automatically.