### PR TITLE
Summarised the versioning policy in the documentation

### DIFF
--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -1,4 +1,5 @@
-**Changelog**
+Changelog
+---------
 
 .. list-table::
    :widths: 15 15 70
@@ -146,3 +147,12 @@
    * - ``24.1.0``
      - 12/10/21
      - Added ``platform_strings`` to :carta:ref:`RegisterViewerAck` message.
+
+Versioning
+----------
+
+* Major version change (``1.2.3`` -> ``2.0.0``): this is a breaking change.
+* Minor version change (``1.2.3`` -> ``1.3.0``): this is added functionality which is optional and non-breaking.
+* Patch (``1.2.3`` -> ``1.2.4``): this is a change which does not affect functionality (e.g. a typo fix in a comment, or a changed field name).
+
+Some legacy changelog entries may not follow this approach. Only changes to the protocol buffer source files should be recorded here; changes only to this documentation do not require a version bump.

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -9,6 +9,15 @@ CARTA Interface Control Document
 
 .. include:: changelog.rst.txt
 
+Versioning
+----------
+
+* Major version change (``1.2.3`` -> ``2.0.0``): this is a breaking change.
+* Minor version change (``1.2.3`` -> ``1.3.0``): this is added functionality which is optional and non-breaking.
+* Patch (``1.2.3`` -> ``1.2.4``): this is a change which does not affect functionality (e.g. a typo fix in a comment, or a changed field name).
+
+Some legacy changelog entries may not follow this approach. Only changes to the protocol buffer source files should be recorded here; changes only to this documentation do not require a version bump.
+
 .. toctree::
    :numbered: 3
    :caption: Contents:

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -9,15 +9,6 @@ CARTA Interface Control Document
 
 .. include:: changelog.rst.txt
 
-Versioning
-----------
-
-* Major version change (``1.2.3`` -> ``2.0.0``): this is a breaking change.
-* Minor version change (``1.2.3`` -> ``1.3.0``): this is added functionality which is optional and non-breaking.
-* Patch (``1.2.3`` -> ``1.2.4``): this is a change which does not affect functionality (e.g. a typo fix in a comment, or a changed field name).
-
-Some legacy changelog entries may not follow this approach. Only changes to the protocol buffer source files should be recorded here; changes only to this documentation do not require a version bump.
-
 .. toctree::
    :numbered: 3
    :caption: Contents:


### PR DESCRIPTION
I have added a brief summary of our versioning policy to the documentation (under the changelog; in the changelog file).