### PR TITLE
Add keep field to MomentRequest

### DIFF
--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -184,7 +184,7 @@ Changelog
      - 08/09/22
      - Added ``spectral_range``, ``reverse``, and ``keep`` to :carta:ref:`PvRequest` message.
    * - ``28.3.0``
-     - 28/11/22
+     - 30/11/22
      - Added ``keep`` to :carta:ref:`MomentRequest` message.
 
 Versioning

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -180,6 +180,9 @@ Changelog
    * - ``28.1.0``
      - 17/06/22
      - Added ``region_id`` and ``fov_info`` to :carta:ref:`FittingRequest` message.
+   * - ``28.2.0``
+     - 28/09/22
+     - Added ``keep`` to :carta:ref:`MomentRequest` message.
 
 Versioning
 ----------

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,7 +1,7 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 17 June 2022
+:Date: 30 November 2022
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
 :Version: 28.3.0
 :ICD Version Integer: 28

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -5,7 +5,7 @@ CARTA Interface Control Document
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
 :Version: 28.3.0
 :ICD Version Integer: 28
-:CARTA Target: Version 3.0
+:CARTA Target: Version 4.0
 
 .. include:: changelog.rst.txt
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -3,7 +3,7 @@ CARTA Interface Control Document
 
 :Date: 17 June 2022
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.2.0
+:Version: 28.3.0
 :ICD Version Integer: 28
 :CARTA Target: Version 3.0
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1161,6 +1161,10 @@ Source file: `request/moment_request.proto <https://github.com/CARTAvis/carta-pr
      - :carta:refc:`FloatBounds`
      - 
      - 
+   * - keep
+     - bool
+     - 
+     - 
 
 .. carta:class:: carta-b2f momentresponse
 

--- a/request/moment_request.proto
+++ b/request/moment_request.proto
@@ -13,6 +13,7 @@ message MomentRequest {
     IntBounds spectral_range = 5;
     MomentMask mask = 6;
     FloatBounds pixel_range = 7;
+    bool keep = 8;
 }
 
 message MomentResponse {


### PR DESCRIPTION
Like PvRequest, a boolen "keep" field was added to MomentRequest (default false = replace previous moment images).