### PR TITLE
Mark/add axes numbers

### DIFF
--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -189,6 +189,9 @@ Changelog
    * - ``28.4.0``
      - 05/12/22
      - Added additional fields to :carta:ref:`FittingRequest` and :carta:ref:`FittingResponse` for generating model and residual images. Added :carta:ref:`FittingProgress` and :carta:ref:`StopFitting` messages for updaing progress and canceling tasks.
+   * - ``28.5.0``
+     - 10/01/23
+     - Added axes numbers to :carta:ref:`FileInfoExtended` message for dealing with swapped axes image cubes.
 
 Versioning
 ----------

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -47,18 +47,26 @@ Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob
      - Type
      - Label
      - Description
-   * - directions
+   * - dir_x
      - sfixed32
-     - repeated
      - 
+     - Direction X axis number
+   * - dir_y
+     - sfixed32
+     - 
+     - Direction Y axis number
    * - spectral
      - sfixed32
      - 
-     - 
+     - Spectral axis number
    * - stokes
      - sfixed32
      - 
+     - Stokes axis number
+   * - depth
+     - sfixed32
      - 
+     - Depth axis is non-render axis that is not stokes (if any)
 
 .. carta:class:: carta-sub beam
 

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -47,14 +47,14 @@ Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob
      - Type
      - Label
      - Description
-   * - dir_x
+   * - spatial_x
      - sfixed32
      - 
-     - Direction X axis number
-   * - dir_y
+     - Spatial X axis number
+   * - spatial_y
      - sfixed32
      - 
-     - Direction Y axis number
+     - Spatial Y axis number
    * - spectral
      - sfixed32
      - 

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -27,6 +27,39 @@ Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob
      - 
      - 
 
+.. carta:class:: carta-sub axesnumbers
+
+.. _axesnumbers:
+
+AxesNumbers
+~~~~~~~~~~~
+
+Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
+
+
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - directions
+     - sfixed32
+     - repeated
+     - 
+   * - spectral
+     - sfixed32
+     - 
+     - 
+   * - stokes
+     - sfixed32
+     - 
+     - 
+
 .. carta:class:: carta-sub beam
 
 .. _beam:
@@ -437,6 +470,10 @@ Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob
      - :carta:refc:`HeaderEntry`
      - repeated
      - 
+   * - axes_numbers
+     - :carta:refc:`AxesNumbers`
+     - 
+     - Axes numbers for directions, spectral, and stokes
 
 .. carta:class:: carta-sub filterconfig
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,11 +1,11 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 05 December 2022
+:Date: 10 January 2022
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.4.0
+:Version: 28.5.0
 :ICD Version Integer: 28
-:CARTA Target: Version 4.0
+:CARTA Target: Version 5.0
 
 .. include:: changelog.rst.txt
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -5,7 +5,7 @@ CARTA Interface Control Document
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
 :Version: 28.5.0
 :ICD Version Integer: 28
-:CARTA Target: Version 5.0
+:CARTA Target: Version 4.0
 
 .. include:: changelog.rst.txt
 

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -62,10 +62,10 @@ message HeaderEntry {
 }
 
 message AxesNumbers {
-    // Direction X axis number
-    sfixed32 dir_x = 1;
-    // Direction Y axis number
-    sfixed32 dir_y = 2;
+    // Spatial X axis number
+    sfixed32 spatial_x = 1;
+    // Spatial Y axis number
+    sfixed32 spatial_y = 2;
     // Spectral axis number
     sfixed32 spectral = 3;
     // Stokes axis number

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -62,9 +62,16 @@ message HeaderEntry {
 }
 
 message AxesNumbers {
-    repeated sfixed32 directions = 1;
-    sfixed32 spectral = 2;
-    sfixed32 stokes = 3;
+    // Direction X axis number
+    sfixed32 dir_x = 1;
+    // Direction Y axis number
+    sfixed32 dir_y = 2;
+    // Spectral axis number
+    sfixed32 spectral = 3;
+    // Stokes axis number
+    sfixed32 stokes = 4;
+    // Depth axis is non-render axis that is not stokes (if any)
+    sfixed32 depth = 5;
 }
 
 message IntBounds {

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -49,6 +49,8 @@ message FileInfoExtended {
     // Header entries from header string or attributes
     repeated HeaderEntry header_entries = 7;
     repeated HeaderEntry computed_entries = 8;
+    // Axes numbers for directions, spectral, and stokes
+    AxesNumbers axes_numbers = 9;
 }
 
 message HeaderEntry {
@@ -57,6 +59,12 @@ message HeaderEntry {
     EntryType entry_type = 3;
     double numeric_value = 4;
     string comment = 5;
+}
+
+message AxesNumbers {
+    repeated sfixed32 directions = 1;
+    sfixed32 spectral = 2;
+    sfixed32 stokes = 3;
 }
 
 message IntBounds {


### PR DESCRIPTION
This adds a new sub-message `AxesNumbers` in the message `FileInfoExtended` and passes it to the frontend. So the frontend can decide which axes to be rendered (axis number is 1 or 2). And which is the depth axis (axis number > 2) for non-stokes axis. This is for the backend [PR 1194](https://github.com/CARTAvis/carta-backend/pull/1194) and the frontend [PR 2011](https://github.com/CARTAvis/carta-frontend/pull/2011).