### PR TITLE
Yuhsuan/model residual image

### DIFF
--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -186,6 +186,9 @@ Changelog
    * - ``28.3.0``
      - 30/11/22
      - Added ``keep`` to :carta:ref:`MomentRequest` message.
+   * - ``28.4.0``
+     - 05/12/22
+     - Added additional fields to :carta:ref:`FittingRequest` and :carta:ref:`FittingResponse` for generating model and residual images. Added :carta:ref:`FittingProgress` and :carta:ref:`StopFitting` messages for updaing progress and canceling tasks.
 
 Versioning
 ----------

--- a/docs/src/enums.rst.txt
+++ b/docs/src/enums.rst.txt
@@ -525,6 +525,12 @@ Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blo
    * - :carta:refc:`VECTOR_OVERLAY_TILE_DATA`
      - 82
      - 
+   * - :carta:refc:`FITTING_PROGRESS`
+     - 83
+     - 
+   * - :carta:refc:`STOP_FITTING`
+     - 84
+     - 
 
 .. carta:class:: carta-sub filefeatureflags
 
@@ -662,6 +668,38 @@ Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blo
    * - UNKNOWN
      - 6
      - 
+
+.. carta:class:: carta-sub fittingsolvertype
+
+.. _fittingsolvertype:
+
+FittingSolverType
+~~~~~~~~~~~~~~~~~
+
+Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/enums.proto>`_
+
+Types of solvers for the linear least squares system in image fittings
+
+.. list-table::
+   :widths: 33 33 33
+   :header-rows: 1
+   :class: proto
+
+   * - Name
+     - Number
+     - Description
+   * - Qr
+     - 0
+     - Uses a rank revealing QR decomposition
+   * - Cholesky
+     - 1
+     - Uses a Cholesky decomposition
+   * - Mcholesky
+     - 2
+     - Uses a modified Cholesky decomposition
+   * - Svd
+     - 3
+     - Uses a singular value decomposition
 
 .. carta:class:: carta-sub moment
 

--- a/docs/src/image_fitting.rst
+++ b/docs/src/image_fitting.rst
@@ -3,7 +3,9 @@
 Image fitting
 -----------------
 
-Users can fit multiple 2D Gaussian components to the selected file with the image fitting widget. Frontend sends :carta:ref:`FITTING_REQUEST` with ``file_id``, ``region_id``, and initial values. Backend fits the current channel and polarization of the file and responds with :carta:ref:`FITTING_RESPONSE`. The sequence diagram is shown below:
+Users can fit multiple 2D Gaussian components to the selected file with the image fitting widget. Frontend sends :carta:ref:`FITTING_REQUEST` with ``file_id``, ``region_id``, ``initial_values``, and other settings. Backend fits the current channel and polarization of the file. For each fitting iteration, backend sends back :carta:ref:`FITTING_PROGRESS` to update the progress. When the fitting is complete, backend responds with :carta:ref:`FITTING_RESPONSE`.
+Users can cancel the requested fitting with the progress widget. Frontend sends :carta:ref:`STOP_FITTING`, and backend sents back :carta:ref:`FITTING_RESPONSE` after the fitting is canceled.
+The sequence diagram is shown below:
 
 .. uml::
     
@@ -24,9 +26,15 @@ Users can fit multiple 2D Gaussian components to the selected file with the imag
     activate Frontend
     Frontend -> Backend : FITTING_REQUEST
     activate Backend
-    Backend -> Backend : 2D Gaussian fitting
+    Backend -> Backend : Setup 2D Gaussian fitting
+loop
+    Backend -> Backend : One fitting iteration
+    Frontend <-- Backend : FITTING_PROGRESS
+end
+    User -> Frontend : (Cancels the requested fitting)
+    Frontend -> Backend : (STOP_FITTING)
     Frontend <-- Backend : FITTING_RESPONSE
     deactivate Backend
     User <-- Frontend : Displays fitting results
     deactivate Frontend
-    
+

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -3,7 +3,7 @@ CARTA Interface Control Document
 
 :Date: 30 November 2022
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.3.0
+:Version: 28.4.0
 :ICD Version Integer: 28
 :CARTA Target: Version 4.0
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,7 +1,7 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 30 November 2022
+:Date: 05 December 2022
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
 :Version: 28.4.0
 :ICD Version Integer: 28

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -823,6 +823,36 @@ Gives a list of available files (and their types), as well as subdirectories
      - 
      - 
 
+.. carta:class:: carta-b2f fittingprogress
+
+.. _fittingprogress:
+
+FittingProgress
+~~~~~~~~~~~~~~~
+
+Source file: `request/fitting_request.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/request/fitting_request.proto>`_
+
+FITTING_PROGRESS:
+Updates the progress of the requested fitting.
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - file_id
+     - sfixed32
+     - 
+     - File ID of the image to be fit
+   * - progress
+     - float
+     - 
+     - Progess of the fitting procedure, ranging from 0 to 1
+
 .. carta:class:: carta-f2b fittingrequest
 
 .. _fittingrequest:
@@ -865,6 +895,22 @@ Backend responds with :carta:refc:`FITTING_RESPONSE`
      - :carta:refc:`RegionInfo`
      - 
      - Field of view parameters
+   * - create_model_image
+     - bool
+     - 
+     - Whether to create a model image of the fitting result
+   * - create_residual_image
+     - bool
+     - 
+     - Whether to create a residual image of the fitting result
+   * - offset
+     - float
+     - 
+     - Background level offset
+   * - solver
+     - :carta:refc:`FittingSolverType`
+     - 
+     - Solver of the linear least squares system in the fitting
 
 .. carta:class:: carta-b2f fittingresponse
 
@@ -908,6 +954,14 @@ Gives results and log of 2D Gaussian image fitting.
      - string
      - 
      - Fitting log
+   * - model_image
+     - :carta:refc:`OpenFileAck`
+     - 
+     - Fitting result: model image
+   * - residual_image
+     - :carta:refc:`OpenFileAck`
+     - 
+     - Fitting result: residual image
 
 .. carta:class:: carta-f2b histogramconfig
 
@@ -2991,6 +3045,32 @@ Source file: `request/file_list.proto <https://github.com/CARTAvis/carta-protobu
      - :carta:refc:`FileListType`
      - 
      - 
+
+.. carta:class:: carta-f2b stopfitting
+
+.. _stopfitting:
+
+StopFitting
+~~~~~~~~~~~
+
+Source file: `request/fitting_request.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/request/fitting_request.proto>`_
+
+STOP_FITTING:
+Cancels the requested fitting.
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - file_id
+     - sfixed32
+     - 
+     - Stop image fitting with respect to the image file id
 
 .. carta:class:: carta-f2b stopmomentcalc
 

--- a/request/fitting_request.proto
+++ b/request/fitting_request.proto
@@ -3,6 +3,7 @@ package CARTA;
 
 import "open_file.proto";
 import "defs.proto";
+import "enums.proto";
 
 // FITTING_REQUEST:
 // Requests 2D Gaussian image fitting with given initial values.
@@ -22,6 +23,10 @@ message FittingRequest {
     bool create_model_image = 6;
     // Whether to create a residual image of the fitting result
     bool create_residual_image = 7;
+    // Background level offset
+    float offset = 8;
+    // Solver of the linear least squares system in the fitting
+    FittingSolverType solver = 9;
 }
 
 // FITTING_RESPONSE:
@@ -44,6 +49,8 @@ message FittingResponse {
     OpenFileAck residual_image = 7;
 }
 
+// FITTING_PROGRESS:
+// Updates the progress of the requested fitting.
 message FittingProgress {
     // File ID of the image to be fit
     sfixed32 file_id = 1;
@@ -51,6 +58,8 @@ message FittingProgress {
     float progress = 2;
 }
 
+// STOP_FITTING:
+// Cancels the requested fitting.
 message StopFitting {
     // Stop image fitting with respect to the image file id
     sfixed32 file_id = 1;

--- a/request/fitting_request.proto
+++ b/request/fitting_request.proto
@@ -43,3 +43,15 @@ message FittingResponse {
     // Fitting result: residual image
     OpenFileAck residual_image = 7;
 }
+
+message FittingProgress {
+    // File ID of the image to be fit
+    sfixed32 file_id = 1;
+    // Progess of the fitting procedure, ranging from 0 to 1
+    float progress = 2;
+}
+
+message StopFitting {
+    // Stop image fitting with respect to the image file id
+    sfixed32 file_id = 1;
+}

--- a/request/fitting_request.proto
+++ b/request/fitting_request.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package CARTA;
 
+import "open_file.proto";
 import "defs.proto";
 
 // FITTING_REQUEST:
@@ -17,6 +18,10 @@ message FittingRequest {
     sfixed32 region_id = 4;
     // Field of view parameters
     RegionInfo fov_info = 5;
+    // Whether to create a model image of the fitting result
+    bool create_model_image = 6;
+    // Whether to create a residual image of the fitting result
+    bool create_residual_image = 7;
 }
 
 // FITTING_RESPONSE:
@@ -33,4 +38,8 @@ message FittingResponse {
     repeated GaussianComponent result_errors = 4;
     // Fitting log
     string log = 5;
+    // Fitting result: model image
+    OpenFileAck model_image = 6;
+    // Fitting result: residual image
+    OpenFileAck residual_image = 7;
 }

--- a/shared/enums.proto
+++ b/shared/enums.proto
@@ -300,3 +300,11 @@ enum ProfileAxisType {
     Offset = 0;
     Distance = 1;
 }
+
+// Types of solvers for the linear least squares system in image fittings
+enum FittingSolverType {
+    Qr = 0; // Uses a rank revealing QR decomposition
+    Cholesky = 1; // Uses a Cholesky decomposition
+    Mcholesky = 2; // Uses a modified Cholesky decomposition
+    Svd = 3; // Uses a singular value decomposition
+}

--- a/shared/enums.proto
+++ b/shared/enums.proto
@@ -75,6 +75,8 @@ enum EventType {
     FITTING_RESPONSE = 80;
     SET_VECTOR_OVERLAY_PARAMETERS = 81;
     VECTOR_OVERLAY_TILE_DATA = 82;
+    FITTING_PROGRESS = 83;
+    STOP_FITTING = 84;
 }
 
 enum SessionType {


### PR DESCRIPTION
**Description**

* added messages for creating images, updating progress, and cancelling task
* updated the behaviour document of image fitting
* added messages for setting fitting background level offset and solver type (to be implemented; added in this branch so that we won't need any new version bump for image fitting in the future)

Corresponding PRs:
 https://github.com/CARTAvis/carta-frontend/pull/2060
https://github.com/CARTAvis/carta-backend/pull/1222

**Todo**

- [x] add changelog and version bump