### PR TITLE
Additional messages and fields for PV preview

### DIFF
--- a/control/region.proto
+++ b/control/region.proto
@@ -12,6 +12,8 @@ message SetRegion {
     sfixed32 region_id = 2;
     // Region parameters
     RegionInfo region_info = 3;
+    // Update region for pv preview only
+    bool preview_region = 4;
 }
 
 

--- a/control/stop_pv_calc.proto
+++ b/control/stop_pv_calc.proto
@@ -2,11 +2,16 @@ syntax = "proto3";
 package CARTA;
 
 message StopPvCalc {
-    // Cancel the PV image/preview calculation for the image file id
+    // Stop the PV image calculation for the image file id
     sfixed32 file_id = 1;
 }
 
 message StopPvPreview {
-    // Stop the PV preview for the image file id to release resources
-    sfixed32 file_id = 1;
+    // Stop the PV preview for the preview viewer id
+    sfixed32 preview_id = 1;
+}
+
+message ClosePvPreview {
+    // Close the PV preview for the preview viewer id
+    sfixed32 preview_id = 1;
 }

--- a/control/stop_pv_calc.proto
+++ b/control/stop_pv_calc.proto
@@ -2,6 +2,11 @@ syntax = "proto3";
 package CARTA;
 
 message StopPvCalc {
-    // Stop the PV image calculation with respect to the image file id
+    // Cancel the PV image/preview calculation for the image file id
+    sfixed32 file_id = 1;
+}
+
+message StopPvPreview {
+    // Stop the PV preview for the image file id to release resources
     sfixed32 file_id = 1;
 }

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -190,7 +190,7 @@ Changelog
      - 05/12/22
      - Added additional fields to :carta:ref:`FittingRequest` and :carta:ref:`FittingResponse` for generating model and residual images. Added :carta:ref:`FittingProgress` and :carta:ref:`StopFitting` messages for updating progress and canceling tasks.
    * - ``28.5.0``
-     - 23/02/23
+     - 23/03/02
      - Added sub-message :carta:ref:`PvPreviewSettings` to :carta:ref:`PvRequest` and message :carta:ref:`PvPreviewData` to :carta:ref:`PvResponse` for generating a PV preview image. Added :carta:ref:`StopPvPreview` to cancel preview image and :carta:ref:`ClosePvPreview` to release preview resources.
 
 Versioning

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -189,6 +189,9 @@ Changelog
    * - ``28.4.0``
      - 05/12/22
      - Added additional fields to :carta:ref:`FittingRequest` and :carta:ref:`FittingResponse` for generating model and residual images. Added :carta:ref:`FittingProgress` and :carta:ref:`StopFitting` messages for updaing progress and canceling tasks.
+   * - ``28.5.0``
+     - 31/01/23
+     - Added ``rebin_xy`` and ``rebin_z`` fields to :carta:ref:`PvRequest` for generating a PV preview image.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -190,8 +190,8 @@ Changelog
      - 05/12/22
      - Added additional fields to :carta:ref:`FittingRequest` and :carta:ref:`FittingResponse` for generating model and residual images. Added :carta:ref:`FittingProgress` and :carta:ref:`StopFitting` messages for updating progress and canceling tasks.
    * - ``28.5.0``
-     - 08/02/23
-     - Added submessage fields :carta:ref:`PvPreviewSettings` to :carta:ref:`PvRequest` and :carta:ref:`PvPreviewImage` to :carta:ref:`PvResponse` for generating a PV preview image. Added :carta:ref:`StopPvPreview` to indicate preview is no longer requested.
+     - 15/02/23
+     - Added submessage fields :carta:ref:`PvPreviewSettings` to :carta:ref:`PvRequest` and :carta:ref:`PvPreviewImage` to :carta:ref:`PvResponse` for generating a PV preview image. Added :carta:ref:`StopPvPreview` to cancel preview image and :carta:ref:`ClosePvPreview` to release preview resources.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -188,10 +188,10 @@ Changelog
      - Added ``keep`` to :carta:ref:`MomentRequest` message.
    * - ``28.4.0``
      - 05/12/22
-     - Added additional fields to :carta:ref:`FittingRequest` and :carta:ref:`FittingResponse` for generating model and residual images. Added :carta:ref:`FittingProgress` and :carta:ref:`StopFitting` messages for updaing progress and canceling tasks.
+     - Added additional fields to :carta:ref:`FittingRequest` and :carta:ref:`FittingResponse` for generating model and residual images. Added :carta:ref:`FittingProgress` and :carta:ref:`StopFitting` messages for updating progress and canceling tasks.
    * - ``28.5.0``
-     - 31/01/23
-     - Added ``rebin_xy`` and ``rebin_z`` fields to :carta:ref:`PvRequest` for generating a PV preview image.
+     - 08/02/23
+     - Added submessage fields :carta:ref:`PvPreviewSettings` to :carta:ref:`PvRequest` and :carta:ref:`PvPreviewImage` to :carta:ref:`PvResponse` for generating a PV preview image. Added :carta:ref:`StopPvPreview` to indicate preview is no longer requested.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -190,17 +190,17 @@ Changelog
      - 05/12/22
      - Added additional fields to :carta:ref:`FittingRequest` and :carta:ref:`FittingResponse` for generating model and residual images. Added :carta:ref:`FittingProgress` and :carta:ref:`StopFitting` messages for updating progress and canceling tasks.
    * - ``28.5.0``
-     - 23/03/02
-     - Added sub-message :carta:ref:`PvPreviewSettings` to :carta:ref:`PvRequest` and message :carta:ref:`PvPreviewData` to :carta:ref:`PvResponse` for generating a PV preview image. Added :carta:ref:`StopPvPreview` to cancel preview image and :carta:ref:`ClosePvPreview` to release preview resources.
-   * - ``28.6.0``
      - 10/01/23
      - Added axes numbers to :carta:ref:`FileInfoExtended` message for dealing with swapped axes image cubes.
-   * - ``28.7.0``
+   * - ``28.6.0``
      - 17/03/23
      - Added additional fields to :carta:ref:`FittingResponse` for image fitting background offset as a free parameter.
-   * - ``28.8.0``
+   * - ``28.7.0``
      - 23/03/23
      - Added annotation regions to :carta:ref:`RegionType` and added additional style parameters in :carta:ref:`AnnotationStyle` to :carta:ref:`RegionStyle`.
+   * - ``28.8.0``
+     - 28/04/23
+     - Added sub-message :carta:ref:`PvPreviewSettings` to :carta:ref:`PvRequest` and message :carta:ref:`PvPreviewData` to :carta:ref:`PvResponse` for generating a PV preview image. Added :carta:ref:`StopPvPreview` to cancel preview image and :carta:ref:`ClosePvPreview` to release preview resources.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -190,8 +190,8 @@ Changelog
      - 05/12/22
      - Added additional fields to :carta:ref:`FittingRequest` and :carta:ref:`FittingResponse` for generating model and residual images. Added :carta:ref:`FittingProgress` and :carta:ref:`StopFitting` messages for updating progress and canceling tasks.
    * - ``28.5.0``
-     - 15/02/23
-     - Added submessage fields :carta:ref:`PvPreviewSettings` to :carta:ref:`PvRequest` and :carta:ref:`PvPreviewImage` to :carta:ref:`PvResponse` for generating a PV preview image. Added :carta:ref:`StopPvPreview` to cancel preview image and :carta:ref:`ClosePvPreview` to release preview resources.
+     - 23/02/23
+     - Added sub-message :carta:ref:`PvPreviewSettings` to :carta:ref:`PvRequest` and message :carta:ref:`PvPreviewData` to :carta:ref:`PvResponse` for generating a PV preview image. Added :carta:ref:`StopPvPreview` to cancel preview image and :carta:ref:`ClosePvPreview` to release preview resources.
 
 Versioning
 ----------

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -975,6 +975,14 @@ Preview parameters of a :carta:refc:`PV_REQUEST`
      - sfixed32
      - 
      - Downsampling in z axis
+   * - compression_type
+     - :carta:refc:`CompressionType`
+     - 
+     - The compression algorithm to use
+   * - compression_quality
+     - float
+     - 
+     - Compression quality switch
 
 .. carta:class:: carta-sub regioninfo
 

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -829,39 +829,6 @@ Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob
      - 
      - 
 
-.. carta:class:: carta-sub pvpreviewimage
-
-.. _pvpreviewimage:
-
-PvPreviewImage
-~~~~~~~~~~~~~~
-
-Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
-
-Image returned for a :carta:refc:`PV_REQUEST` in preview mode
-
-.. list-table::
-   :widths: 20 20 20 40
-   :header-rows: 1
-   :class: proto
-
-   * - Field
-     - Type
-     - Label
-     - Description
-   * - preview_id
-     - sfixed32
-     - 
-     - Preview ID for the PV preview viewer
-   * - file_info_extended
-     - :carta:refc:`FileInfoExtended`
-     - 
-     - Extended file info (WCS, header info)
-   * - raw_values_fp32
-     - bytes
-     - 
-     - PV preview image data
-
 .. carta:class:: carta-sub pvpreviewsettings
 
 .. _pvpreviewsettings:

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -838,7 +838,7 @@ PvPreviewImage
 
 Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
 
-Response to a :carta:refc:`PvRequest` in preview mode
+Response to a :carta:refc:`PV_REQUEST` in preview mode
 
 .. list-table::
    :widths: 20 20 20 40
@@ -867,7 +867,7 @@ PvPreviewSettings
 
 Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
 
-Parameters of a :carta:refc:`PvRequest` in preview mode
+Parameters of a :carta:refc:`PV_REQUEST` in preview mode
 
 .. list-table::
    :widths: 20 20 20 40

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -838,7 +838,7 @@ PvPreviewImage
 
 Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
 
-Response to a :carta:refc:`PV_REQUEST` in preview mode
+Image returned for a :carta:refc:`PV_REQUEST` in preview mode
 
 .. list-table::
    :widths: 20 20 20 40
@@ -849,6 +849,10 @@ Response to a :carta:refc:`PV_REQUEST` in preview mode
      - Type
      - Label
      - Description
+   * - preview_id
+     - sfixed32
+     - 
+     - Preview ID for the PV preview viewer
    * - file_info_extended
      - :carta:refc:`FileInfoExtended`
      - 
@@ -856,7 +860,7 @@ Response to a :carta:refc:`PV_REQUEST` in preview mode
    * - raw_values_fp32
      - bytes
      - 
-     - Downsampled PV image data
+     - PV preview image data
 
 .. carta:class:: carta-sub pvpreviewsettings
 
@@ -867,7 +871,7 @@ PvPreviewSettings
 
 Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
 
-Parameters of a :carta:refc:`PV_REQUEST` in preview mode
+Preview parameters of a :carta:refc:`PV_REQUEST`
 
 .. list-table::
    :widths: 20 20 20 40
@@ -878,6 +882,10 @@ Parameters of a :carta:refc:`PV_REQUEST` in preview mode
      - Type
      - Label
      - Description
+   * - preview_id
+     - sfixed32
+     - 
+     - Preview ID for the PV preview viewer
    * - region_id
      - sfixed32
      - 

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -829,6 +829,68 @@ Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob
      - 
      - 
 
+.. carta:class:: carta-sub pvpreviewimage
+
+.. _pvpreviewimage:
+
+PvPreviewImage
+~~~~~~~~~~~~~~
+
+Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
+
+Response to a :carta:refc:`PvRequest` in preview mode
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - file_info_extended
+     - :carta:refc:`FileInfoExtended`
+     - 
+     - Extended file info (WCS, header info)
+   * - raw_values_fp32
+     - bytes
+     - 
+     - Downsampled PV image data
+
+.. carta:class:: carta-sub pvpreviewsettings
+
+.. _pvpreviewsettings:
+
+PvPreviewSettings
+~~~~~~~~~~~~~~~~~
+
+Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
+
+Parameters of a :carta:refc:`PvRequest` in preview mode
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - region_id
+     - sfixed32
+     - 
+     - Region ID for the subimage in the xy plane
+   * - rebin_xy
+     - sfixed32
+     - 
+     - Downsampling in xy axes
+   * - rebin_z
+     - sfixed32
+     - 
+     - Downsampling in z axis
+
 .. carta:class:: carta-sub regioninfo
 
 .. _regioninfo:

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -979,10 +979,14 @@ Preview parameters of a :carta:refc:`PV_REQUEST`
      - :carta:refc:`CompressionType`
      - 
      - The compression algorithm to use
-   * - compression_quality
+   * - image_compression_quality
      - float
      - 
-     - Compression quality switch
+     - Compression quality from frontend performance preferences
+   * - animation_compression_quality
+     - float
+     - 
+     - 
 
 .. carta:class:: carta-sub regioninfo
 

--- a/docs/src/enums.rst.txt
+++ b/docs/src/enums.rst.txt
@@ -534,6 +534,9 @@ Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blo
    * - :carta:refc:`STOP_PV_PREVIEW`
      - 85
      - 
+   * - :carta:refc:`CLOSE_PV_PREVIEW`
+     - 86
+     - 
 
 .. carta:class:: carta-sub filefeatureflags
 

--- a/docs/src/enums.rst.txt
+++ b/docs/src/enums.rst.txt
@@ -531,11 +531,14 @@ Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blo
    * - :carta:refc:`STOP_FITTING`
      - 84
      - 
-   * - :carta:refc:`STOP_PV_PREVIEW`
+   * - :carta:refc:`PV_PREVIEW_DATA`
      - 85
      - 
-   * - :carta:refc:`CLOSE_PV_PREVIEW`
+   * - :carta:refc:`STOP_PV_PREVIEW`
      - 86
+     - 
+   * - :carta:refc:`CLOSE_PV_PREVIEW`
+     - 87
      - 
 
 .. carta:class:: carta-sub filefeatureflags

--- a/docs/src/enums.rst.txt
+++ b/docs/src/enums.rst.txt
@@ -531,6 +531,9 @@ Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blo
    * - :carta:refc:`STOP_FITTING`
      - 84
      - 
+   * - :carta:refc:`STOP_PV_PREVIEW`
+     - 85
+     - 
 
 .. carta:class:: carta-sub filefeatureflags
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -3,7 +3,7 @@ CARTA Interface Control Document
 
 :Date: 28 April 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.8.0
+:Version: 28.9.0
 :ICD Version Integer: 28
 :CARTA Target: Version 4.0
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,7 +1,7 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 08 February 2023
+:Date: 15 February 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
 :Version: 28.5.0
 :ICD Version Integer: 28

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,9 +1,9 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 23 March 2023
+:Date: 28 April 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.7.0
+:Version: 28.8.0
 :ICD Version Integer: 28
 :CARTA Target: Version 4.0
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -3,7 +3,7 @@ CARTA Interface Control Document
 
 :Date: 05 December 2022
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.4.0
+:Version: 28.5.0
 :ICD Version Integer: 28
 :CARTA Target: Version 4.0
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,7 +1,7 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 15 February 2023
+:Date: 23 February 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
 :Version: 28.5.0
 :ICD Version Integer: 28

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,7 +1,7 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 05 December 2022
+:Date: 08 February 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
 :Version: 28.5.0
 :ICD Version Integer: 28

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,7 +1,7 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 23 February 2023
+:Date: 02 March 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
 :Version: 28.5.0
 :ICD Version Integer: 28

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -2537,6 +2537,10 @@ Creates or updates a region. Backend responds with :carta:refc:`SET_REGION_ACK`
      - :carta:refc:`RegionInfo`
      - 
      - Region parameters
+   * - preview_region
+     - bool
+     - 
+     - Update region for pv preview only
 
 .. carta:class:: carta-b2f setregionack
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1500,11 +1500,15 @@ Data stream for PV preview image
    * - image_info
      - :carta:refc:`FileInfoExtended`
      - 
-     - PV preview image extended file info
+     - Image extended file info
    * - image_data
      - bytes
      - 
-     - PV preview image data (uncompressed FP32)
+     - Image data. For uncompressed data, this is converted into FP32, while for compressed data, this is passed to the compression library for decompression.
+   * - nan_encodings
+     - bytes
+     - 
+     - Run-length encodings of NaN values used to restore the NaN values after decompression.
    * - width
      - sfixed32
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1517,6 +1517,10 @@ Data stream for PV preview image
      - :carta:refc:`FloatBounds`
      - 
      - :carta:refc:`Histogram` min/max, for rendering
+   * - histogram
+     - :carta:refc:`Histogram`
+     - 
+     - :carta:refc:`Histogram`, to tune rendering
 
 .. carta:class:: carta-b2f pvprogress
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1463,7 +1463,7 @@ Source file: `request/pv_request.proto <https://github.com/CARTAvis/carta-protob
    * - file_id
      - sfixed32
      - 
-     - File ID of the source image for the PV generator
+     - File ID of the source image
    * - progress
      - float
      - 
@@ -1492,7 +1492,7 @@ Source file: `request/pv_request.proto <https://github.com/CARTAvis/carta-protob
    * - file_id
      - sfixed32
      - 
-     - File ID of the source image for the PV generator
+     - File ID of the source image
    * - region_id
      - sfixed32
      - 
@@ -1549,11 +1549,11 @@ Source file: `request/pv_request.proto <https://github.com/CARTAvis/carta-protob
    * - open_file_ack
      - :carta:refc:`OpenFileAck`
      - 
-     - :carta:refc:`PvRequest` generator result: generated PV image
+     - :carta:refc:`PV_REQUEST` generator result: generated PV image
    * - preview_image
      - :carta:refc:`PvPreviewImage`
      - 
-     - :carta:refc:`PvRequest` preview result: generated PV image
+     - :carta:refc:`PV_REQUEST` preview result: generated PV image
    * - cancel
      - bool
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -387,6 +387,31 @@ Instructs the backend to close a file with a given file ID
      - 
      - Which "file" slot to close
 
+.. carta:class:: carta-f2b closepvpreview
+
+.. _closepvpreview:
+
+ClosePvPreview
+~~~~~~~~~~~~~~
+
+Source file: `control/stop_pv_calc.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/control/stop_pv_calc.proto>`_
+
+
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - preview_id
+     - sfixed32
+     - 
+     - Close the PV preview for the preview viewer id
+
 .. carta:class:: carta-f2b concatstokesfiles
 
 .. _concatstokesfiles:
@@ -1463,7 +1488,11 @@ Source file: `request/pv_request.proto <https://github.com/CARTAvis/carta-protob
    * - file_id
      - sfixed32
      - 
-     - File ID of the source image
+     - File ID of the source image for the PV generator
+   * - preview_id
+     - sfixed32
+     - 
+     - Preview ID of the PV preview viewer
    * - progress
      - float
      - 
@@ -3132,7 +3161,7 @@ Source file: `control/stop_pv_calc.proto <https://github.com/CARTAvis/carta-prot
    * - file_id
      - sfixed32
      - 
-     - Cancel the PV image/preview calculation for the image file id
+     - Stop the PV image calculation for the image file id
 
 .. carta:class:: carta-f2b stoppvpreview
 
@@ -3154,10 +3183,10 @@ Source file: `control/stop_pv_calc.proto <https://github.com/CARTAvis/carta-prot
      - Type
      - Label
      - Description
-   * - file_id
+   * - preview_id
      - sfixed32
      - 
-     - Stop the PV preview for the image file id to release resources
+     - Stop the PV preview for the preview viewer id
 
 .. carta:class:: carta-b2f vectoroverlaytiledata
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1463,11 +1463,11 @@ Source file: `request/pv_request.proto <https://github.com/CARTAvis/carta-protob
    * - file_id
      - sfixed32
      - 
-     - 
+     - File ID of the source image for the PV generator
    * - progress
      - float
      - 
-     - 
+     - Progress indicator, ranging from 0 to 1
 
 .. carta:class:: carta-f2b pvrequest
 
@@ -1492,27 +1492,35 @@ Source file: `request/pv_request.proto <https://github.com/CARTAvis/carta-protob
    * - file_id
      - sfixed32
      - 
-     - 
+     - File ID of the source image for the PV generator
    * - region_id
      - sfixed32
      - 
-     - 
+     - Region ID of the PV cut in the source image
    * - width
      - sfixed32
      - 
-     - 
+     - Averaging width along PV cut
    * - spectral_range
      - :carta:refc:`IntBounds`
      - 
-     - 
+     - Range of channels to be used in velocity axis
    * - reverse
      - bool
      - 
-     - 
+     - Flag whether to generate [Offset, Freq] image or the reverse
    * - keep
      - bool
      - 
+     - Flag whether to keep or replace previously-generated images
+   * - rebin_xy
+     - sfixed32
      - 
+     - Downsampling in xy axes; 0 generate, > 0 preview
+   * - rebin_z
+     - sfixed32
+     - 
+     - Downsampling in z axis; 0 generate, > 0 preview
 
 .. carta:class:: carta-b2f pvresponse
 
@@ -1537,19 +1545,19 @@ Source file: `request/pv_request.proto <https://github.com/CARTAvis/carta-protob
    * - success
      - bool
      - 
-     - 
+     - Defines whether :carta:refc:`PV_REQUEST` was successful
    * - message
      - string
      - 
-     - 
+     - Error message (if applicable)
    * - open_file_ack
      - :carta:refc:`OpenFileAck`
      - 
-     - 
+     - :carta:refc:`PvRequest` result: generated PV image
    * - cancel
      - bool
      - 
-     - 
+     - Defines whether :carta:refc:`PV_REQUEST` was canceled
 
 .. carta:class:: carta-b2f rastertiledata
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1465,6 +1465,39 @@ Response for :carta:refc:`OPEN_FILE`. Also supplies file information
      - repeated
      - :carta:refc:`Beam` table for multiple-beam images
 
+.. carta:class:: carta-b2f pvpreviewdata
+
+.. _pvpreviewdata:
+
+PvPreviewData
+~~~~~~~~~~~~~
+
+Source file: `stream/pv_preview.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/stream/pv_preview.proto>`_
+
+Data stream for PV preview image
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - preview_id
+     - sfixed32
+     - 
+     - Preview ID for the PV preview viewer
+   * - image_info
+     - :carta:refc:`FileInfoExtended`
+     - 
+     - PV preview image extended file info
+   * - image_data
+     - bytes
+     - 
+     - PV preview image data (uncompressed FP32)
+
 .. carta:class:: carta-b2f pvprogress
 
 .. _pvprogress:
@@ -1578,11 +1611,11 @@ Source file: `request/pv_request.proto <https://github.com/CARTAvis/carta-protob
    * - open_file_ack
      - :carta:refc:`OpenFileAck`
      - 
-     - :carta:refc:`PV_REQUEST` generator result: generated PV image
-   * - preview_image
-     - :carta:refc:`PvPreviewImage`
+     - PV generator result: generated PV image
+   * - preview_data
+     - :carta:refc:`PvPreviewData`
      - 
-     - :carta:refc:`PV_REQUEST` preview result: generated PV image
+     - PV preview result: generated PV image
    * - cancel
      - bool
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1513,18 +1513,10 @@ Source file: `request/pv_request.proto <https://github.com/CARTAvis/carta-protob
      - bool
      - 
      - Flag whether to keep or replace previously-generated images
-   * - sub_region_id
-     - sfixed32
+   * - preview_settings
+     - :carta:refc:`PvPreviewSettings`
      - 
-     - Region ID for the subimage in the xy plane; 0 generate, > 0 preview
-   * - rebin_xy
-     - sfixed32
-     - 
-     - Downsampling in xy axes; 0 generate, > 0 preview
-   * - rebin_z
-     - sfixed32
-     - 
-     - Downsampling in z axis; 0 generate, > 0 preview
+     - Parameters for preview mode
 
 .. carta:class:: carta-b2f pvresponse
 
@@ -1557,7 +1549,11 @@ Source file: `request/pv_request.proto <https://github.com/CARTAvis/carta-protob
    * - open_file_ack
      - :carta:refc:`OpenFileAck`
      - 
-     - :carta:refc:`PvRequest` result: generated PV image
+     - :carta:refc:`PvRequest` generator result: generated PV image
+   * - preview_image
+     - :carta:refc:`PvPreviewImage`
+     - 
+     - :carta:refc:`PvRequest` preview result: generated PV image
    * - cancel
      - bool
      - 
@@ -3136,7 +3132,32 @@ Source file: `control/stop_pv_calc.proto <https://github.com/CARTAvis/carta-prot
    * - file_id
      - sfixed32
      - 
-     - Stop the PV image calculation with respect to the image file id
+     - Cancel the PV image/preview calculation for the image file id
+
+.. carta:class:: carta-f2b stoppvpreview
+
+.. _stoppvpreview:
+
+StopPvPreview
+~~~~~~~~~~~~~
+
+Source file: `control/stop_pv_calc.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/control/stop_pv_calc.proto>`_
+
+
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - file_id
+     - sfixed32
+     - 
+     - Stop the PV preview for the image file id to release resources
 
 .. carta:class:: carta-b2f vectoroverlaytiledata
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1497,6 +1497,18 @@ Data stream for PV preview image
      - bytes
      - 
      - PV preview image data (uncompressed FP32)
+   * - width
+     - sfixed32
+     - 
+     - Dimensions of data
+   * - height
+     - sfixed32
+     - 
+     - 
+   * - histogram_bounds
+     - :carta:refc:`FloatBounds`
+     - 
+     - :carta:refc:`Histogram` min/max, for rendering
 
 .. carta:class:: carta-b2f pvprogress
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1508,11 +1508,15 @@ Source file: `request/pv_request.proto <https://github.com/CARTAvis/carta-protob
    * - reverse
      - bool
      - 
-     - Flag whether to generate [Offset, Freq] image or the reverse
+     - Flag whether to generate [Spatial, Spectral] image or reverse
    * - keep
      - bool
      - 
      - Flag whether to keep or replace previously-generated images
+   * - sub_region_id
+     - sfixed32
+     - 
+     - Region ID for the subimage in the xy plane; 0 generate, > 0 preview
    * - rebin_xy
      - sfixed32
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1513,6 +1513,14 @@ Data stream for PV preview image
      - sfixed32
      - 
      - 
+   * - compression_type
+     - :carta:refc:`CompressionType`
+     - 
+     - The compression algorithm used
+   * - compression_quality
+     - float
+     - 
+     - Compression quality switch
    * - histogram_bounds
      - :carta:refc:`FloatBounds`
      - 

--- a/request/pv_request.proto
+++ b/request/pv_request.proto
@@ -35,8 +35,10 @@ message PvResponse {
 }
 
 message PvProgress {
-    // File ID of the source image
+    // File ID of the source image for the PV generator
     sfixed32 file_id = 1;
+    // Preview ID of the PV preview viewer
+    sfixed32 preview_id = 2;
     // Progress indicator, ranging from 0 to 1
-    float progress = 2;
+    float progress = 3;
 }

--- a/request/pv_request.proto
+++ b/request/pv_request.proto
@@ -13,14 +13,16 @@ message PvRequest {
     sfixed32 width = 3;
     // Range of channels to be used in velocity axis
     IntBounds spectral_range = 4;
-    // Flag whether to generate [Offset, Freq] image or the reverse
+    // Flag whether to generate [Spatial, Spectral] image or reverse
     bool reverse = 5;
     // Flag whether to keep or replace previously-generated images
     bool keep = 6;
+    // Region ID for the subimage in the xy plane; 0 generate, > 0 preview
+    sfixed32 sub_region_id = 7;
     // Downsampling in xy axes; 0 generate, > 0 preview
-    sfixed32 rebin_xy = 7;
+    sfixed32 rebin_xy = 8;
     // Downsampling in z axis; 0 generate, > 0 preview
-    sfixed32 rebin_z = 8;
+    sfixed32 rebin_z = 9;
 }
 
 message PvResponse {

--- a/request/pv_request.proto
+++ b/request/pv_request.proto
@@ -17,12 +17,8 @@ message PvRequest {
     bool reverse = 5;
     // Flag whether to keep or replace previously-generated images
     bool keep = 6;
-    // Region ID for the subimage in the xy plane; 0 generate, > 0 preview
-    sfixed32 sub_region_id = 7;
-    // Downsampling in xy axes; 0 generate, > 0 preview
-    sfixed32 rebin_xy = 8;
-    // Downsampling in z axis; 0 generate, > 0 preview
-    sfixed32 rebin_z = 9;
+    // Parameters for preview mode
+    PvPreviewSettings preview_settings = 7;
 }
 
 message PvResponse {
@@ -30,10 +26,12 @@ message PvResponse {
     bool success = 1;
     // Error message (if applicable)
     string message = 2;
-    // PvRequest result: generated PV image
+    // PvRequest generator result: generated PV image
     OpenFileAck open_file_ack = 3;
+    // PvRequest preview result: generated PV image
+    PvPreviewImage preview_image = 4;
     // Defines whether PV_REQUEST was canceled
-    bool cancel = 4;
+    bool cancel = 5;
 }
 
 message PvProgress {

--- a/request/pv_request.proto
+++ b/request/pv_request.proto
@@ -3,6 +3,7 @@ package CARTA;
 
 import "defs.proto";
 import "open_file.proto";
+import "pv_preview.proto";
 
 message PvRequest {
     // File ID of the source image
@@ -26,10 +27,10 @@ message PvResponse {
     bool success = 1;
     // Error message (if applicable)
     string message = 2;
-    // PV_REQUEST generator result: generated PV image
+    // PV generator result: generated PV image
     OpenFileAck open_file_ack = 3;
-    // PV_REQUEST preview result: generated PV image
-    PvPreviewImage preview_image = 4;
+    // PV preview result: generated PV image
+    PvPreviewData preview_data = 4;
     // Defines whether PV_REQUEST was canceled
     bool cancel = 5;
 }

--- a/request/pv_request.proto
+++ b/request/pv_request.proto
@@ -5,22 +5,38 @@ import "defs.proto";
 import "open_file.proto";
 
 message PvRequest {
+    // File ID of the source image for the PV generator
     sfixed32 file_id = 1;
+    // Region ID of the PV cut in the source image
     sfixed32 region_id = 2;
+    // Averaging width along PV cut
     sfixed32 width = 3;
+    // Range of channels to be used in velocity axis
     IntBounds spectral_range = 4;
+    // Flag whether to generate [Offset, Freq] image or the reverse
     bool reverse = 5;
+    // Flag whether to keep or replace previously-generated images
     bool keep = 6;
+    // Downsampling in xy axes; 0 generate, > 0 preview
+    sfixed32 rebin_xy = 7;
+    // Downsampling in z axis; 0 generate, > 0 preview
+    sfixed32 rebin_z = 8;
 }
 
 message PvResponse {
+    // Defines whether PV_REQUEST was successful
     bool success = 1;
+    // Error message (if applicable)
     string message = 2;
+    // PvRequest result: generated PV image
     OpenFileAck open_file_ack = 3;
+    // Defines whether PV_REQUEST was canceled
     bool cancel = 4;
 }
 
 message PvProgress {
+    // File ID of the source image for the PV generator
     sfixed32 file_id = 1;
+    // Progress indicator, ranging from 0 to 1
     float progress = 2;
 }

--- a/request/pv_request.proto
+++ b/request/pv_request.proto
@@ -5,7 +5,7 @@ import "defs.proto";
 import "open_file.proto";
 
 message PvRequest {
-    // File ID of the source image for the PV generator
+    // File ID of the source image
     sfixed32 file_id = 1;
     // Region ID of the PV cut in the source image
     sfixed32 region_id = 2;
@@ -26,16 +26,16 @@ message PvResponse {
     bool success = 1;
     // Error message (if applicable)
     string message = 2;
-    // PvRequest generator result: generated PV image
+    // PV_REQUEST generator result: generated PV image
     OpenFileAck open_file_ack = 3;
-    // PvRequest preview result: generated PV image
+    // PV_REQUEST preview result: generated PV image
     PvPreviewImage preview_image = 4;
     // Defines whether PV_REQUEST was canceled
     bool cancel = 5;
 }
 
 message PvProgress {
-    // File ID of the source image for the PV generator
+    // File ID of the source image
     sfixed32 file_id = 1;
     // Progress indicator, ranging from 0 to 1
     float progress = 2;

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -242,7 +242,7 @@ message GaussianComponent {
     double pa = 4;
 }
 
-// Parameters of a PvRequest in preview mode
+// Parameters of a PV_REQUEST in preview mode
 message PvPreviewSettings {
     // Region ID for the subimage in the xy plane
     sfixed32 region_id = 1;
@@ -252,7 +252,7 @@ message PvPreviewSettings {
     sfixed32 rebin_z = 3;
 }
 
-// Response to a PvRequest in preview mode
+// Response to a PV_REQUEST in preview mode
 message PvPreviewImage {
     // Extended file info (WCS, header info)
     FileInfoExtended file_info_extended = 1;

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -294,4 +294,8 @@ message PvPreviewSettings {
     sfixed32 rebin_xy = 3;
     // Downsampling in z axis
     sfixed32 rebin_z = 4;
+    // The compression algorithm to use
+    CompressionType compression_type = 5;
+    // Compression quality switch
+    float compression_quality = 6;
 }

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -296,6 +296,7 @@ message PvPreviewSettings {
     sfixed32 rebin_z = 4;
     // The compression algorithm to use
     CompressionType compression_type = 5;
-    // Compression quality switch
-    float compression_quality = 6;
+    // Compression quality from frontend performance preferences
+    float image_compression_quality = 6;
+    float animation_compression_quality = 7;
 }

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -242,20 +242,24 @@ message GaussianComponent {
     double pa = 4;
 }
 
-// Parameters of a PV_REQUEST in preview mode
+// Preview parameters of a PV_REQUEST
 message PvPreviewSettings {
+    // Preview ID for the PV preview viewer
+    sfixed32 preview_id = 1;
     // Region ID for the subimage in the xy plane
-    sfixed32 region_id = 1;
+    sfixed32 region_id = 2;
     // Downsampling in xy axes
-    sfixed32 rebin_xy = 2;
+    sfixed32 rebin_xy = 3;
     // Downsampling in z axis
-    sfixed32 rebin_z = 3;
+    sfixed32 rebin_z = 4;
 }
 
-// Response to a PV_REQUEST in preview mode
+// Image returned for a PV_REQUEST in preview mode
 message PvPreviewImage {
+    // Preview ID for the PV preview viewer
+    sfixed32 preview_id = 1;
     // Extended file info (WCS, header info)
-    FileInfoExtended file_info_extended = 1;
-    // Downsampled PV image data
+    FileInfoExtended file_info_extended = 2;
+    // PV preview image data
     bytes raw_values_fp32 = 3;
-}    
+}

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -241,3 +241,21 @@ message GaussianComponent {
     // position angle in degrees
     double pa = 4;
 }
+
+// Parameters of a PvRequest in preview mode
+message PvPreviewSettings {
+    // Region ID for the subimage in the xy plane
+    sfixed32 region_id = 1;
+    // Downsampling in xy axes
+    sfixed32 rebin_xy = 2;
+    // Downsampling in z axis
+    sfixed32 rebin_z = 3;
+}
+
+// Response to a PvRequest in preview mode
+message PvPreviewImage {
+    // Extended file info (WCS, header info)
+    FileInfoExtended file_info_extended = 1;
+    // Downsampled PV image data
+    bytes raw_values_fp32 = 3;
+}    

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -253,13 +253,3 @@ message PvPreviewSettings {
     // Downsampling in z axis
     sfixed32 rebin_z = 4;
 }
-
-// Image returned for a PV_REQUEST in preview mode
-message PvPreviewImage {
-    // Preview ID for the PV preview viewer
-    sfixed32 preview_id = 1;
-    // Extended file info (WCS, header info)
-    FileInfoExtended file_info_extended = 2;
-    // PV preview image data
-    bytes raw_values_fp32 = 3;
-}

--- a/shared/enums.proto
+++ b/shared/enums.proto
@@ -77,6 +77,7 @@ enum EventType {
     VECTOR_OVERLAY_TILE_DATA = 82;
     FITTING_PROGRESS = 83;
     STOP_FITTING = 84;
+    STOP_PV_PREVIEW = 85;
 }
 
 enum SessionType {

--- a/shared/enums.proto
+++ b/shared/enums.proto
@@ -77,8 +77,9 @@ enum EventType {
     VECTOR_OVERLAY_TILE_DATA = 82;
     FITTING_PROGRESS = 83;
     STOP_FITTING = 84;
-    STOP_PV_PREVIEW = 85;
-    CLOSE_PV_PREVIEW = 86;
+    PV_PREVIEW_DATA = 85;
+    STOP_PV_PREVIEW = 86;
+    CLOSE_PV_PREVIEW = 87;
 }
 
 enum SessionType {

--- a/shared/enums.proto
+++ b/shared/enums.proto
@@ -78,6 +78,7 @@ enum EventType {
     FITTING_PROGRESS = 83;
     STOP_FITTING = 84;
     STOP_PV_PREVIEW = 85;
+    CLOSE_PV_PREVIEW = 86;
 }
 
 enum SessionType {

--- a/stream/pv_preview.proto
+++ b/stream/pv_preview.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+package CARTA;
+
+import "defs.proto";
+
+// Data stream for PV preview image
+message PvPreviewData {
+    // Preview ID for the PV preview viewer
+    sfixed32 preview_id = 1;
+    // PV preview image extended file info
+    FileInfoExtended image_info = 2;
+    // PV preview image data (uncompressed FP32)
+    bytes image_data = 3;
+}

--- a/stream/pv_preview.proto
+++ b/stream/pv_preview.proto
@@ -11,4 +11,9 @@ message PvPreviewData {
     FileInfoExtended image_info = 2;
     // PV preview image data (uncompressed FP32)
     bytes image_data = 3;
+    // Dimensions of data
+    sfixed32 width = 4;
+    sfixed32 height = 5;
+    // Histogram min/max, for rendering
+    FloatBounds histogram_bounds = 6;
 }

--- a/stream/pv_preview.proto
+++ b/stream/pv_preview.proto
@@ -8,19 +8,22 @@ import "enums.proto";
 message PvPreviewData {
     // Preview ID for the PV preview viewer
     sfixed32 preview_id = 1;
-    // PV preview image extended file info
+    // Image extended file info
     FileInfoExtended image_info = 2;
-    // PV preview image data (uncompressed FP32)
+    // Image data. For uncompressed data, this is converted into FP32, while for compressed data,
+    // this is passed to the compression library for decompression.
     bytes image_data = 3;
+    // Run-length encodings of NaN values used to restore the NaN values after decompression.
+    bytes nan_encodings = 4;
     // Dimensions of data
-    sfixed32 width = 4;
-    sfixed32 height = 5;
+    sfixed32 width = 5;
+    sfixed32 height = 6;
     // The compression algorithm used
-    CompressionType compression_type = 6;
+    CompressionType compression_type = 7;
     // Compression quality switch
-    float compression_quality = 7;
+    float compression_quality = 8;
     // Histogram min/max, for rendering
-    FloatBounds histogram_bounds = 8;
+    FloatBounds histogram_bounds = 9;
     // Histogram, to tune rendering
-    Histogram histogram = 9;
+    Histogram histogram = 10;
 }

--- a/stream/pv_preview.proto
+++ b/stream/pv_preview.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package CARTA;
 
 import "defs.proto";
+import "enums.proto";
 
 // Data stream for PV preview image
 message PvPreviewData {
@@ -14,8 +15,12 @@ message PvPreviewData {
     // Dimensions of data
     sfixed32 width = 4;
     sfixed32 height = 5;
+    // The compression algorithm used
+    CompressionType compression_type = 6;
+    // Compression quality switch
+    float compression_quality = 7;
     // Histogram min/max, for rendering
-    FloatBounds histogram_bounds = 6;
+    FloatBounds histogram_bounds = 8;
     // Histogram, to tune rendering
-    Histogram histogram = 7;
+    Histogram histogram = 9;
 }

--- a/stream/pv_preview.proto
+++ b/stream/pv_preview.proto
@@ -16,4 +16,6 @@ message PvPreviewData {
     sfixed32 height = 5;
     // Histogram min/max, for rendering
     FloatBounds histogram_bounds = 6;
+    // Histogram, to tune rendering
+    Histogram histogram = 7;
 }


### PR DESCRIPTION
Adds preview submessages PvPreviewSettings to PvRequest and PvPreviewData to PvResponse for the PV preview feature.  Adds a preview_region flag to SetRegion to indicate that only the PV preview should be updated, not all data streams using the PV cut region.  Adds new messages StopPvPreview to cancel the preview and ClosePvPreview to remove any stored settings and data.