### PR TITLE
Mark/customize histogram calculations

### DIFF
--- a/control/region_requirements.proto
+++ b/control/region_requirements.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package CARTA;
 
+import "defs.proto";
 import "enums.proto";
 
 // SET_STATS_REQUIREMENTS:
@@ -34,6 +35,8 @@ message SetHistogramRequirements {
         string coordinate = 1;
         sfixed32 channel = 2;
         sfixed32 num_bins = 3;
+        bool fixed_bounds = 4;
+        FloatBounds bounds = 5;
     }
 }
 

--- a/control/region_requirements.proto
+++ b/control/region_requirements.proto
@@ -30,14 +30,6 @@ message SetHistogramRequirements {
     // List of required histograms, along with the number of bins. If the channel is -1, the current channel is used. If the channel is -2,
     // the histogram is constructed over all channels. If the number of bins is less than zero, an automatic bin size is used, based on the number of values.
     repeated HistogramConfig histograms = 3;
-
-    message HistogramConfig {
-        string coordinate = 1;
-        sfixed32 channel = 2;
-        sfixed32 num_bins = 3;
-        bool fixed_bounds = 4;
-        FloatBounds bounds = 5;
-    }
 }
 
 // SET_SPATIAL_REQUIREMENTS:

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -198,6 +198,9 @@ Changelog
    * - ``28.7.0``
      - 23/03/23
      - Added annotation regions to :carta:ref:`RegionType` and added additional style parameters in :carta:ref:`AnnotationStyle` to :carta:ref:`RegionStyle`.
+   * - ``28.8.0``
+     - 14/04/23
+     - Added number of bins and pixel bounds to :carta:ref:`HistogramConfig` in :carta:ref:`SetHistogramRequirements` message. Added :carta:ref:`HistogramConfig` to :carta:ref:`RegionHistogramData` message.
 
 Versioning
 ----------

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -741,6 +741,55 @@ Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob
      - 
      - 
 
+.. carta:class:: carta-sub histogramconfig
+
+.. _histogramconfig:
+
+HistogramConfig
+~~~~~~~~~~~~~~~
+
+Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
+
+
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - coordinate
+     - string
+     - 
+     - 
+   * - channel
+     - sfixed32
+     - 
+     - 
+   * - fixed_num_bins
+     - bool
+     - 
+     - 
+   * - num_bins
+     - sfixed32
+     - 
+     - 
+   * - bin_width
+     - double
+     - 
+     - 
+   * - fixed_bounds
+     - bool
+     - 
+     - 
+   * - bounds
+     - :carta:refc:`FloatBounds`
+     - 
+     - 
+
 .. carta:class:: carta-sub imagebounds
 
 .. _imagebounds:

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -782,7 +782,7 @@ Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob
      - 
      - 
    * - bounds
-     - :carta:refc:`FloatBounds`
+     - :carta:refc:`DoubleBounds`
      - 
      - 
 

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -777,10 +777,6 @@ Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob
      - sfixed32
      - 
      - 
-   * - bin_width
-     - double
-     - 
-     - 
    * - fixed_bounds
      - bool
      - 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,9 +1,9 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 23 March 2023
+:Date: 24 April 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.7.0
+:Version: 28.8.0
 :ICD Version Integer: 28
 :CARTA Target: Version 4.0
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -971,47 +971,6 @@ Gives results and log of 2D Gaussian image fitting.
      - 
      - Fitting result: error of background level offset
 
-.. carta:class:: carta-f2b histogramconfig
-
-.. _histogramconfig:
-
-HistogramConfig
-~~~~~~~~~~~~~~~
-
-Source file: `control/region_requirements.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/control/region_requirements.proto>`_
-
-
-
-.. list-table::
-   :widths: 20 20 20 40
-   :header-rows: 1
-   :class: proto
-
-   * - Field
-     - Type
-     - Label
-     - Description
-   * - coordinate
-     - string
-     - 
-     - 
-   * - channel
-     - sfixed32
-     - 
-     - 
-   * - num_bins
-     - sfixed32
-     - 
-     - 
-   * - fixed_bounds
-     - bool
-     - 
-     - 
-   * - bounds
-     - :carta:refc:`FloatBounds`
-     - 
-     - 
-
 .. carta:class:: carta-f2b imageproperties
 
 .. _imageproperties:
@@ -1772,6 +1731,10 @@ Stats data for a specific region
      - float
      - 
      - Progress indicator, in the case of partial histogram results being sent
+   * - config
+     - :carta:refc:`HistogramConfig`
+     - 
+     - :carta:refc:`Histogram` configuration from the frontend
 
 .. carta:class:: carta-f2b regionlistrequest
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1003,6 +1003,14 @@ Source file: `control/region_requirements.proto <https://github.com/CARTAvis/car
      - sfixed32
      - 
      - 
+   * - fixed_bounds
+     - bool
+     - 
+     - 
+   * - bounds
+     - :carta:refc:`FloatBounds`
+     - 
+     - 
 
 .. carta:class:: carta-f2b imageproperties
 

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -139,6 +139,16 @@ message Histogram {
     double std_dev = 6;
 }
 
+message HistogramConfig {
+    string coordinate = 1;
+    sfixed32 channel = 2;
+    bool fixed_num_bins = 3;
+    sfixed32 num_bins = 4;
+    double bin_width = 5;
+    bool fixed_bounds = 6;
+    FloatBounds bounds = 7;
+}
+
 message RegionInfo {
     // The type of region described by the control points. The meaning of the control points will differ,
     // depending on the type of region being defined.

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -144,9 +144,8 @@ message HistogramConfig {
     sfixed32 channel = 2;
     bool fixed_num_bins = 3;
     sfixed32 num_bins = 4;
-    double bin_width = 5;
-    bool fixed_bounds = 6;
-    FloatBounds bounds = 7;
+    bool fixed_bounds = 5;
+    FloatBounds bounds = 6;
 }
 
 message RegionInfo {

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -145,7 +145,7 @@ message HistogramConfig {
     bool fixed_num_bins = 3;
     sfixed32 num_bins = 4;
     bool fixed_bounds = 5;
-    FloatBounds bounds = 6;
+    DoubleBounds bounds = 6;
 }
 
 message RegionInfo {

--- a/stream/region_histogram.proto
+++ b/stream/region_histogram.proto
@@ -18,4 +18,6 @@ message RegionHistogramData {
     Histogram histograms = 5;
     // Progress indicator, in the case of partial histogram results being sent
     float progress = 6;
+    // Histogram configuration from the frontend
+    HistogramConfig config = 7;
 }


### PR DESCRIPTION
This modified the protobuf message `HistogramConfig` and added options for the number of bins or pixel bounds which will be applied in histogram calculations in the backend.