### PR TITLE
Fixes the problem of resuming LEL images

### DIFF
--- a/control/resume_session.proto
+++ b/control/resume_session.proto
@@ -10,14 +10,15 @@ import "concat_stokes_files.proto";
 message ImageProperties {
     string directory = 1;
     string file = 2;
-    string hdu = 3;
-    sfixed32 file_id = 4;
-    RenderMode render_mode = 5;
-    sfixed32 channel = 6;
-    sfixed32 stokes = 7;
-    map<sfixed32, RegionInfo> regions = 8;
-    SetContourParameters contour_settings = 9;
-    repeated StokesFile stokes_files = 10;
+    bool lel_expr = 3;
+    string hdu = 4;
+    sfixed32 file_id = 5;
+    RenderMode render_mode = 6;
+    sfixed32 channel = 7;
+    sfixed32 stokes = 8;
+    map<sfixed32, RegionInfo> regions = 9;
+    SetContourParameters contour_settings = 10;
+    repeated StokesFile stokes_files = 11;
 }
 
 message ResumeSession {

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -204,6 +204,9 @@ Changelog
    * - ``28.9.0``
      - 28/04/23
      - Added sub-message :carta:ref:`PvPreviewSettings` to :carta:ref:`PvRequest` and message :carta:ref:`PvPreviewData` to :carta:ref:`PvResponse` for generating a PV preview image. Added :carta:ref:`StopPvPreview` to cancel preview image and :carta:ref:`ClosePvPreview` to release preview resources.
+   * - ``28.10.0``
+     - 18/05/23
+     - Added ``lel_expr`` to :carta:ref:`ImageProperties` message.
 
 Versioning
 ----------

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,9 +1,9 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 28 April 2023
+:Date: 18 May 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.9.0
+:Version: 28.10.0
 :ICD Version Integer: 28
 :CARTA Target: Version 4.0
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1024,6 +1024,10 @@ Source file: `control/resume_session.proto <https://github.com/CARTAvis/carta-pr
      - string
      - 
      - 
+   * - lel_expr
+     - bool
+     - 
+     - 
    * - hdu
      - string
      - 


### PR DESCRIPTION
This is used to fix the [backend issue](https://github.com/CARTAvis/carta-backend/issues/1226) about resuming LEL images by adding a bool variable `lel_expr` in the `ImageProperties` message.