### PR TITLE
AIPS beam support

### DIFF
--- a/control/open_file.proto
+++ b/control/open_file.proto
@@ -20,6 +20,8 @@ message OpenFile {
     RenderMode render_mode = 5;
     // Defines whether file is LEL expression
     bool lel_expr = 6;
+    // Defines whether to support AIPS beam in FITS history headers
+    bool support_aips_beam = 7;
 }
 
 // OPEN_FILE_ACK

--- a/control/resume_session.proto
+++ b/control/resume_session.proto
@@ -19,6 +19,7 @@ message ImageProperties {
     map<sfixed32, RegionInfo> regions = 9;
     SetContourParameters contour_settings = 10;
     repeated StokesFile stokes_files = 11;
+    bool support_aips_beam = 12;
 }
 
 message ResumeSession {

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -207,6 +207,9 @@ Changelog
    * - ``28.10.0``
      - 18/05/23
      - Added ``lel_expr`` to :carta:ref:`ImageProperties` message.
+   * - ``28.11.0``
+     - 13/06/23
+     - Added ``support_aips_beam`` to :carta:ref:`OpenFile` message.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -208,8 +208,8 @@ Changelog
      - 18/05/23
      - Added ``lel_expr`` to :carta:ref:`ImageProperties` message.
    * - ``28.11.0``
-     - 13/06/23
-     - Added ``support_aips_beam`` to :carta:ref:`FileInfoRequest` and :carta:ref:`OpenFile` messages.
+     - 20/06/23
+     - Added ``support_aips_beam`` to :carta:ref:`FileInfoRequest`, :carta:ref:`OpenFile`, and :carta:ref:`ImageProperties` messages.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -209,7 +209,7 @@ Changelog
      - Added ``lel_expr`` to :carta:ref:`ImageProperties` message.
    * - ``28.11.0``
      - 13/06/23
-     - Added ``support_aips_beam`` to :carta:ref:`OpenFile` message.
+     - Added ``support_aips_beam`` to :carta:ref:`FileInfoRequest` and :carta:ref:`OpenFile` messages.
 
 Versioning
 ----------

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,9 +1,9 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 18 May 2023
+:Date: 13 June 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.10.0
+:Version: 28.11.0
 :ICD Version Integer: 28
 :CARTA Target: Version 4.0
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,7 +1,7 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 13 June 2023
+:Date: 20 June 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
 :Version: 28.11.0
 :ICD Version Integer: 28

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -726,6 +726,10 @@ Backend responds with :carta:refc:`FILE_INFO_RESPONSE`
      - string
      - 
      - Required HDU name (if applicable). If left empty, the first HDU is selected
+   * - support_aips_beam
+     - bool
+     - 
+     - Defines whether to support AIPS beam in FITS history headers
 
 .. carta:class:: carta-b2f fileinforesponse
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1393,6 +1393,10 @@ Backend responds with  :carta:refc:`OPEN_FILE_ACK`
      - bool
      - 
      - Defines whether file is LEL expression
+   * - support_aips_beam
+     - bool
+     - 
+     - Defines whether to support AIPS beam in FITS history headers
 
 .. carta:class:: carta-b2f openfileack
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1064,6 +1064,10 @@ Source file: `control/resume_session.proto <https://github.com/CARTAvis/carta-pr
      - :carta:refc:`StokesFile`
      - repeated
      - 
+   * - support_aips_beam
+     - bool
+     - 
+     - 
 
 .. carta:class:: carta-f2b importregion
 

--- a/request/file_info.proto
+++ b/request/file_info.proto
@@ -13,6 +13,8 @@ message FileInfoRequest {
     string file = 2;
     // Required HDU name (if applicable). If left empty, the first HDU is selected
     string hdu = 3;
+    // Defines whether to support AIPS beam in FITS history headers
+    bool support_aips_beam = 4;
 }
 
 // FILE_INFO_RESPONSE


### PR DESCRIPTION
Support user preference for using the last AIPS beam defined in the HISTORY headers.

A boolean `support_aips_beam` field was added to FileInfoRequest, OpenFile, and ImageProperties in ResumeSession.