### PR TITLE
Add sync id to raster tile sync and data

### DIFF
--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -207,6 +207,9 @@ Changelog
    * - ``28.10.0``
      - 18/05/23
      - Added ``lel_expr`` to :carta:ref:`ImageProperties` message.
+   * - ``28.11.0``
+     - 26/07/23
+     - Added ``sync_id`` to :carta:ref:`RasterTileSync` and :carta:ref:`RasterTileData` messages.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -209,7 +209,7 @@ Changelog
      - Added ``lel_expr`` to :carta:ref:`ImageProperties` message.
    * - ``28.11.0``
      - 26/07/23
-     - Added ``sync_id`` to :carta:ref:`RasterTileSync` and :carta:ref:`RasterTileData` messages.
+     - Added ``sync_id`` and ``tile_count`` to :carta:ref:`RasterTileSync` and :carta:ref:`RasterTileData` messages.
 
 Versioning
 ----------

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -3,7 +3,7 @@ CARTA Interface Control Document
 
 :Date: 18 May 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.10.0
+:Version: 28.11.0
 :ICD Version Integer: 28
 :CARTA Target: Version 4.0
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1672,6 +1672,10 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - sfixed32
      - 
      - The ID of the sync sequence
+   * - tile_count
+     - sfixed32
+     - 
+     - The number of tiles in a sync group
    * - animation_id
      - sfixed32
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1668,6 +1668,10 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - float
      - 
      - Compression quality switch
+   * - sync_id
+     - sfixed32
+     - 
+     - The ID of the sync sequence
    * - animation_id
      - sfixed32
      - 
@@ -1709,6 +1713,10 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - sfixed32
      - 
      - The image stokes coordinate
+   * - sync_id
+     - sfixed32
+     - 
+     - The ID of the sync sequence
    * - animation_id
      - sfixed32
      - 

--- a/stream/raster_tile.proto
+++ b/stream/raster_tile.proto
@@ -15,8 +15,10 @@ message RasterTileSync {
     sfixed32 sync_id = 4;
     // The ID of the animation (if any)
     sfixed32 animation_id = 5;
+    // The number of tiles in a sync group
+    sfixed32 tile_count = 6;
     // Is this a start or end sync message?
-    bool end_sync = 6;
+    bool end_sync = 7;
 }
 
 message RasterTileData {

--- a/stream/raster_tile.proto
+++ b/stream/raster_tile.proto
@@ -11,10 +11,12 @@ message RasterTileSync {
     sfixed32 channel = 2;
     // The image stokes coordinate
     sfixed32 stokes = 3;
+    // The ID of the sync sequence
+    sfixed32 sync_id = 4;
     // The ID of the animation (if any)
-    sfixed32 animation_id = 4;
+    sfixed32 animation_id = 5;
     // Is this a start or end sync message?
-    bool end_sync = 5;
+    bool end_sync = 6;
 }
 
 message RasterTileData {
@@ -28,8 +30,10 @@ message RasterTileData {
     CompressionType compression_type = 4;
     // Compression quality switch
     float compression_quality = 5;
+    // The ID of the sync sequence
+    sfixed32 sync_id = 6;
     // The ID of the animation (if any)
-    sfixed32 animation_id = 6;
+    sfixed32 animation_id = 7;
     // List of tile data
-    repeated TileData tiles = 7;
+    repeated TileData tiles = 8;
 }


### PR DESCRIPTION
Add sync_id field to RasterTileSync and RasterTileData messages so that messages from multiple, simultaneous streams can be sorted out.