### PR TITLE
Add a frontend version info to the RegisterViewer message

### DIFF
--- a/control/register_viewer.proto
+++ b/control/register_viewer.proto
@@ -10,11 +10,13 @@ message RegisterViewer {
     // Unique session ID parameter (can be generated using UUID libraries).
     // Passing in an existing session ID can be used for resuming sessions
     fixed32 session_id = 1;
+    // Frontend version used to check if it matches the backend.
+    string version = 2;
     // Optional user-specific API key to be used for basic authentication.
     // Could be an encrypted JWT for secure authentication.
-    string api_key = 2;
+    string api_key = 3;
     // Optional feature bitflag specifying client-side feature set
-    fixed32 client_feature_flags = 3;
+    fixed32 client_feature_flags = 4;
 }
 
 // REGISTER_VIEWER_ACK

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1692,10 +1692,6 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - sfixed32
      - 
      - The ID of the sync sequence
-   * - tile_count
-     - sfixed32
-     - 
-     - The number of tiles in a sync group
    * - animation_id
      - sfixed32
      - 
@@ -1745,6 +1741,10 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - sfixed32
      - 
      - The ID of the animation (if any)
+   * - tile_count
+     - sfixed32
+     - 
+     - The number of tiles in a sync group
    * - end_sync
      - bool
      - 
@@ -2020,6 +2020,10 @@ Responds with :carta:refc:`REGISTER_VIEWER_ACK`
      - fixed32
      - 
      - Unique session ID parameter (can be generated using UUID libraries). Passing in an existing session ID can be used for resuming sessions
+   * - version
+     - string
+     - 
+     - Frontend version used to check if it matches the backend.
    * - api_key
      - string
      - 


### PR DESCRIPTION
Modify the `RegisterViewer` message and add a string type variable `version`, which is the frontend version.