### PR TITLE
Yuhsuan/file ids

### DIFF
--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -216,6 +216,9 @@ Changelog
    * - ``28.13.0``
      - 23/08/23
      - Added integrated flux to :carta:ref:`FittingResponse` message.
+   * - ``28.14.0``
+     - 27/10/23
+     - Adjusted file ID generation.
 
 Versioning
 ----------

--- a/docs/src/image_fitting.rst
+++ b/docs/src/image_fitting.rst
@@ -3,8 +3,10 @@
 Image fitting
 -----------------
 
-Users can fit multiple 2D Gaussian components to the selected file with the image fitting widget. Frontend sends :carta:ref:`FITTING_REQUEST` with ``file_id``, ``region_id``, ``initial_values``, and other settings. Backend fits the current channel and polarization of the file. For each fitting iteration, backend sends back :carta:ref:`FITTING_PROGRESS` to update the progress. When the fitting is complete, backend responds with :carta:ref:`FITTING_RESPONSE`.
+Users can fit multiple 2D Gaussian components to the selected file with the image fitting widget. Frontend sends :carta:ref:`FITTING_REQUEST` with ``file_id``, ``region_id``, ``initial_values``, and other settings. Backend fits the current channel and polarization of the file. For each fitting iteration, backend sends back :carta:ref:`FITTING_PROGRESS` to update the progress. When the fitting is complete, backend responds with :carta:ref:`FITTING_RESPONSE`. When there are newly generated modal and residual images, the new file IDs are incremented from the last opened image. 
+
 Users can cancel the requested fitting with the progress widget. Frontend sends :carta:ref:`STOP_FITTING`, and backend sents back :carta:ref:`FITTING_RESPONSE` after the fitting is canceled.
+
 The sequence diagram is shown below:
 
 .. uml::

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -3,7 +3,7 @@ CARTA Interface Control Document
 
 :Date: 14 August 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.13.0
+:Version: 28.14.0
 :ICD Version Integer: 28
 :CARTA Target: Version 4.0
 

--- a/docs/src/moments_generator.rst
+++ b/docs/src/moments_generator.rst
@@ -21,7 +21,7 @@ CARTA should provide the following kinds of moments (sensible name in bold) as s
 -  moments = 10 - **minimum value of the spectrum**
 -  moments = 11 - **coordinate of the minimum value of the spectrum**
 
-The newly generated moment images (multiple moments can be generated at the same time) should be loaded and appended (and match spatially) in CARTA. CARTA should also support the capability to export the images as files in the following formats:
+The newly generated moment images (multiple moments can be generated at the same time) should be loaded and appended (and match spatially) in CARTA. The new file IDs are incremented from the last opened image. CARTA should also support the capability to export the images as files in the following formats:
 
 -  CASA image format
 -  FITS image format


### PR DESCRIPTION
Version bump for https://github.com/CARTAvis/carta-frontend/pull/2275 and https://github.com/CARTAvis/carta-backend/pull/1322.

I suggest a minor version bump because the changes only break some features, but I'm open to other options. I also added some description in the documentation so that the changes are clear.

If the backend branch is linked to a old frontend branch:
1. Resuming sessions fails with generated images. (persistently shows the progress bar)
2. Saving workspaces saves generated images. Loading the workspace shows error toast. (different behavior, but overall the workspace feature works)

If the frontend branch is linked to a old backend branch, no feature breaks.