### PR TITLE
Add fields and message for channel map

### DIFF
--- a/control/channel_map.proto
+++ b/control/channel_map.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+package CARTA;
+
+// CHANNEL_MAP_FLOW_CONTROL
+// Used for informing the backend of which frames have been received
+message ChannelMapFlowControl {
+    // The file ID that the channel map view corresponds to
+    sfixed32 file_id = 1;
+    // The latest flow control channel received
+    sfixed32 received_channel = 2;
+}

--- a/control/contour.proto
+++ b/control/contour.proto
@@ -26,4 +26,6 @@ message SetContourParameters {
     int32 compression_level = 8;
     // Size of contour chunks, in number of vertices. If this is set to zero, partial contour results are not used
     int32 contour_chunk_size = 9;
+    // Channel range for channel map
+    IntBounds channel_range = 10;
 }

--- a/control/set_image_channels.proto
+++ b/control/set_image_channels.proto
@@ -15,6 +15,8 @@ message SetImageChannels {
     sfixed32 stokes = 3;
     // Required tiles when changing channels
     AddRequiredTiles required_tiles = 4;
-    // Optional channels for channel map view
+    // Optional requested channels for channel map view
     IntBounds channel_range = 5;
+    // Optional range of channels for channel map view
+    IntBounds current_range = 6;
 }

--- a/control/set_image_channels.proto
+++ b/control/set_image_channels.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package CARTA;
 
+import "defs.proto";
 import "tiles.proto";
 
 // SET_IMAGE_CHANNELS
@@ -14,4 +15,6 @@ message SetImageChannels {
     sfixed32 stokes = 3;
     // Required tiles when changing channels
     AddRequiredTiles required_tiles = 4;
+    // Optional channels for channel map view
+    IntBounds channel_range = 5;
 }

--- a/control/set_image_channels.proto
+++ b/control/set_image_channels.proto
@@ -19,4 +19,6 @@ message SetImageChannels {
     IntBounds channel_range = 5;
     // Optional range of channels for channel map view
     IntBounds current_range = 6;
+    // Set current image channel during channel map
+    bool channel_map_enabled = 7;
 }

--- a/control/tiles.proto
+++ b/control/tiles.proto
@@ -14,6 +14,8 @@ message AddRequiredTiles {
     CompressionType compression_type = 3;
     // Compression quality switch
     float compression_quality = 4;
+    // Optional list of all tiles in channel map view
+    repeated sfixed32 current_tiles = 5;
 }
 
 // REMOVE_REQUIRED_TILES

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -228,9 +228,9 @@ Changelog
    * - ``29.1.0``
      - 27/08/24
      - Added ``rest_freq`` to :carta:ref:`MomentRequest` message.
-   * - ``29.2.0``
-     - 10/09/24
-     - Added optional ``channel_range`` and ``current_range`` to :carta:ref:`SetImageChannels` message.
+   * - ``30.0.0``
+     - 23/10/24
+     - Added optional ``channel_range`` and ``current_range`` to :carta:ref:`SetImageChannels` message, optional ``current_tiles`` to :carta:ref:`AddRequiredTiles` message, and new message :carta:ref:`ChannelMapFlowControl` to support channel map view.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -220,8 +220,6 @@ Changelog
      - 27/10/23
      - Adjusted file ID generation.
    * - ``28.15.0``
-     - 29/01/24
-     - Added optional channel_range to :carta:ref:`SetImageChannels` message.
      - 23/05/24
      - Added :carta:ref:`RemoteFileRequest` and :carta:ref:`RemoteFileResponse` messages.
    * - ``29.0.0``
@@ -230,6 +228,9 @@ Changelog
    * - ``29.1.0``
      - 27/08/24
      - Added ``rest_freq`` to :carta:ref:`MomentRequest` message.
+   * - ``29.2.0``
+     - 10/09/24
+     - Added optional ``channel_range`` and ``current_range`` to :carta:ref:`SetImageChannels` message.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -216,6 +216,9 @@ Changelog
    * - ``28.13.0``
      - 23/08/23
      - Added integrated flux to :carta:ref:`FittingResponse` message.
+   * - ``28.14.0``
+     - 29/01/24
+     - Added optional channel_range to :carta:ref:`SetImageChannels` message.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -227,6 +227,9 @@ Changelog
    * - ``29.0.0``
      - 26/06/24
      - Added ``overwrite`` to :carta:ref:`SaveFile` and :carta:ref:`ExportRegion` messages.
+   * - ``29.1.0``
+     - 27/08/24
+     - Added ``rest_freq`` to :carta:ref:`MomentRequest` message.
 
 Versioning
 ----------

--- a/docs/src/enums.rst.txt
+++ b/docs/src/enums.rst.txt
@@ -546,6 +546,9 @@ Source file: `shared/enums.proto <https://github.com/CARTAvis/carta-protobuf/blo
    * - :carta:refc:`REMOTE_FILE_RESPONSE`
      - 89
      - 
+   * - :carta:refc:`CHANNEL_MAP_FLOW_CONTROL`
+     - 90
+     - 
 
 .. carta:class:: carta-sub filefeatureflags
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -3,7 +3,7 @@ CARTA Interface Control Document
 
 :Date: 14 August 2023
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.13.0
+:Version: 28.14.0
 :ICD Version Integer: 28
 :CARTA Target: Version 4.0
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -3,7 +3,7 @@ CARTA Interface Control Document
 
 :Date: 27 August 2024
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 29.1.0
+:Version: 29.2.0
 :ICD Version Integer: 29
 :CARTA Target: Version 5.0
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,9 +1,9 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 11 June 2024
+:Date: 27 August 2024
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 29.0.0
+:Version: 29.1.0
 :ICD Version Integer: 29
 :CARTA Target: Version 5.0
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,7 +1,7 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 27 August 2024
+:Date: 10 September 2024
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
 :Version: 29.2.0
 :ICD Version Integer: 29

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,10 +1,10 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 10 September 2024
+:Date: 23 October 2024
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 29.2.0
-:ICD Version Integer: 29
+:Version: 30.0.0
+:ICD Version Integer: 30 
 :CARTA Target: Version 5.0
 
 .. include:: changelog.rst.txt

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -35,6 +35,10 @@ Provides a list of tiles that are required for the specified file
      - float
      - 
      - Compression quality switch
+   * - current_tiles
+     - sfixed32
+     - repeated
+     - Optional list of all tiles in channel map view
 
 .. carta:class:: carta-f2b animationflowcontrol
 
@@ -335,6 +339,36 @@ Source file: `request/catalog_list.proto <https://github.com/CARTAvis/carta-prot
      - bool
      - 
      - 
+
+.. carta:class:: carta-f2b channelmapflowcontrol
+
+.. _channelmapflowcontrol:
+
+ChannelMapFlowControl
+~~~~~~~~~~~~~~~~~~~~~
+
+Source file: `control/channel_map.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/control/channel_map.proto>`_
+
+CHANNEL_MAP_FLOW_CONTROL
+Used for informing the backend of which frames have been received
+
+.. list-table::
+   :widths: 20 20 20 40
+   :header-rows: 1
+   :class: proto
+
+   * - Field
+     - Type
+     - Label
+     - Description
+   * - file_id
+     - sfixed32
+     - 
+     - The file ID that the channel map view corresponds to
+   * - received_channel
+     - sfixed32
+     - 
+     - The latest flow control channel received
 
 .. carta:class:: carta-f2b closecatalogfile
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -2549,6 +2549,10 @@ Sets the contour parameters for a file
      - int32
      - 
      - Size of contour chunks, in number of vertices. If this is set to zero, partial contour results are not used
+   * - channel_range
+     - :carta:refc:`IntBounds`
+     - 
+     - Channel range for channel map
 
 .. carta:class:: carta-f2b setcursor
 
@@ -2659,7 +2663,11 @@ Sets the current image channel and Stokes parameter
    * - channel_range
      - :carta:refc:`IntBounds`
      - 
-     - Optional channels for channel map view
+     - Optional requested channels for channel map view
+   * - current_range
+     - :carta:refc:`IntBounds`
+     - 
+     - Optional range of channels for channel map view
 
 .. carta:class:: carta-f2b setregion
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1247,6 +1247,10 @@ Source file: `request/moment_request.proto <https://github.com/CARTAvis/carta-pr
      - bool
      - 
      - 
+   * - rest_freq
+     - double
+     - 
+     - Set the rest frequency (Hz) of the image
 
 .. carta:class:: carta-b2f momentresponse
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1692,10 +1692,6 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - sfixed32
      - 
      - The ID of the sync sequence
-   * - tile_count
-     - sfixed32
-     - 
-     - The number of tiles in a sync group
    * - animation_id
      - sfixed32
      - 
@@ -1745,6 +1741,10 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - sfixed32
      - 
      - The ID of the animation (if any)
+   * - tile_count
+     - sfixed32
+     - 
+     - The number of tiles in a sync group
    * - end_sync
      - bool
      - 
@@ -2534,6 +2534,10 @@ Sets the current image channel and Stokes parameter
      - :carta:refc:`AddRequiredTiles`
      - 
      - Required tiles when changing channels
+   * - channel_range
+     - :carta:refc:`IntBounds`
+     - 
+     - Optional channels for channel map view
 
 .. carta:class:: carta-f2b setregion
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -2702,6 +2702,10 @@ Sets the current image channel and Stokes parameter
      - :carta:refc:`IntBounds`
      - 
      - Optional range of channels for channel map view
+   * - channel_map_enabled
+     - bool
+     - 
+     - Set current image channel during channel map
 
 .. carta:class:: carta-f2b setregion
 

--- a/request/moment_request.proto
+++ b/request/moment_request.proto
@@ -14,6 +14,8 @@ message MomentRequest {
     MomentMask mask = 6;
     FloatBounds pixel_range = 7;
     bool keep = 8;
+    // Set the rest frequency (Hz) of the image
+    double rest_freq = 9;
 }
 
 message MomentResponse {

--- a/shared/enums.proto
+++ b/shared/enums.proto
@@ -82,6 +82,7 @@ enum EventType {
     CLOSE_PV_PREVIEW = 87;
     REMOTE_FILE_REQUEST = 88;
     REMOTE_FILE_RESPONSE = 89;
+    CHANNEL_MAP_FLOW_CONTROL = 90;
 }
 
 enum SessionType {


### PR DESCRIPTION
To support channel map view:

- optional IntBounds channel_range field has been added to SetImageChannels and SetContourParameters. When channel_range is set, the channel field should be ignored.
- optional IntBounds current_range field has been added to SetImageChannels to enable cancellation of stale channel requests.
- optional repeated current_tiles field has been added to AddRequiredTiles to enable cancellation of stale tile requests.
- new message ChannelMapFlowControl has been added to indicate last received channel in channel map.

