### PR TITLE
Thchang/frontend protobufjs version bump

### DIFF
--- a/build_proto.sh
+++ b/build_proto.sh
@@ -3,8 +3,8 @@ cd "$(dirname "$0")"
 mkdir -p build
 
 printf "Building all message modules..."
-../node_modules/protobufjs/bin/pbjs -p shared -p control -p request -p stream -t static-module -o build/index.js --wrap es6 shared/*.proto control/*.proto request/*.proto stream/*.proto
-../node_modules/protobufjs/bin/pbts -o build/index.d.ts build/index.js
+../node_modules/protobufjs-cli/bin/pbjs -p shared -p control -p request -p stream -t static-module -o build/index.js --wrap es6 shared/*.proto control/*.proto request/*.proto stream/*.proto
+../node_modules/protobufjs-cli/bin/pbts -o build/index.d.ts build/index.js
 printf "...done\n"
 
 #printf "Building Request message module..."


### PR DESCRIPTION
This PR is for frontend `protobufjs` version bump from 6.9.0 to 7.2.6. (https://github.com/CARTAvis/carta-frontend/pull/2361)

`protobufjs` has moved its protobuf building tools to a new package `protobufjs-cli` since 7.0.0. The paths for `pbjs` and `pbts` needs to be changed for frontend protobuf building with the version bump.

