### PR TITLE
Add fitting results of beam deconvolved image to FittingResponse

### DIFF
--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -928,10 +928,6 @@ Backend responds with :carta:refc:`FITTING_RESPONSE`
      - bool
      - 
      - Whether to create a model image of the fitting result
-   * - create_decon_model_image
-     - bool
-     - 
-     - Whether to create a beam deconvolved model image from the fitting result
    * - create_residual_image
      - bool
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -928,6 +928,10 @@ Backend responds with :carta:refc:`FITTING_RESPONSE`
      - bool
      - 
      - Whether to create a model image of the fitting result
+   * - create_decon_model_image
+     - bool
+     - 
+     - Whether to create a beam deconvolved model image from the fitting result
    * - create_residual_image
      - bool
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -987,6 +987,10 @@ Gives results and log of 2D Gaussian image fitting.
      - :carta:refc:`OpenFileAck`
      - 
      - Fitting result: model image
+   * - deconvolved_model_image
+     - :carta:refc:`OpenFileAck`
+     - 
+     - Fitting result: beam deconvolved model image
    * - residual_image
      - :carta:refc:`OpenFileAck`
      - 
@@ -1692,10 +1696,6 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - sfixed32
      - 
      - The ID of the sync sequence
-   * - tile_count
-     - sfixed32
-     - 
-     - The number of tiles in a sync group
    * - animation_id
      - sfixed32
      - 
@@ -1745,6 +1745,10 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - sfixed32
      - 
      - The ID of the animation (if any)
+   * - tile_count
+     - sfixed32
+     - 
+     - The number of tiles in a sync group
    * - end_sync
      - bool
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -979,6 +979,14 @@ Gives results and log of 2D Gaussian image fitting.
      - :carta:refc:`GaussianComponent`
      - repeated
      - Fitting result: errors of the fitted parameters
+   * - result_decon_values
+     - :carta:refc:`GaussianComponent`
+     - repeated
+     - Fitting result: values of the deconvolved fitted parameters
+   * - result_decon_errors
+     - :carta:refc:`GaussianComponent`
+     - repeated
+     - Fitting result: errors of the deconvolved fitted parameters
    * - log
      - string
      - 

--- a/request/fitting_request.proto
+++ b/request/fitting_request.proto
@@ -45,16 +45,18 @@ message FittingResponse {
     string log = 5;
     // Fitting result: model image
     OpenFileAck model_image = 6;
+    // Fitting result: beam deconvolved model image
+    OpenFileAck deconvolved_model_image = 7;
     // Fitting result: residual image
-    OpenFileAck residual_image = 7;
+    OpenFileAck residual_image = 8;
     // Fitting result: background level offset
-    double offset_value = 8;
+    double offset_value = 9;
     // Fitting result: error of background level offset
-    double offset_error = 9;
+    double offset_error = 10;
     // Fitting result: values of integrated flux of each component
-    repeated double integrated_flux_values = 10;
+    repeated double integrated_flux_values = 11;
     // Fitting result: errors of integrated flux of each component
-    repeated double integrated_flux_errors = 11;
+    repeated double integrated_flux_errors = 12;
 }
 
 // FITTING_PROGRESS:

--- a/request/fitting_request.proto
+++ b/request/fitting_request.proto
@@ -41,22 +41,26 @@ message FittingResponse {
     repeated GaussianComponent result_values = 3;
     // Fitting result: errors of the fitted parameters
     repeated GaussianComponent result_errors = 4;
+    // Fitting result: values of the deconvolved fitted parameters
+    repeated GaussianComponent result_decon_values = 5;
+    // Fitting result: errors of the deconvolved fitted parameters
+    repeated GaussianComponent result_decon_errors = 6;
     // Fitting log
-    string log = 5;
+    string log = 7;
     // Fitting result: model image
-    OpenFileAck model_image = 6;
+    OpenFileAck model_image = 8;
     // Fitting result: beam deconvolved model image
-    OpenFileAck deconvolved_model_image = 7;
+    OpenFileAck deconvolved_model_image = 9;
     // Fitting result: residual image
-    OpenFileAck residual_image = 8;
+    OpenFileAck residual_image = 10;
     // Fitting result: background level offset
-    double offset_value = 9;
+    double offset_value = 11;
     // Fitting result: error of background level offset
-    double offset_error = 10;
+    double offset_error = 12;
     // Fitting result: values of integrated flux of each component
-    repeated double integrated_flux_values = 11;
+    repeated double integrated_flux_values = 13;
     // Fitting result: errors of integrated flux of each component
-    repeated double integrated_flux_errors = 12;
+    repeated double integrated_flux_errors = 14;
 }
 
 // FITTING_PROGRESS:

--- a/request/fitting_request.proto
+++ b/request/fitting_request.proto
@@ -21,12 +21,14 @@ message FittingRequest {
     RegionInfo fov_info = 5;
     // Whether to create a model image of the fitting result
     bool create_model_image = 6;
+    // Whether to create a beam deconvolved model image from the fitting result
+    bool create_decon_model_image = 7;
     // Whether to create a residual image of the fitting result
-    bool create_residual_image = 7;
+    bool create_residual_image = 8;
     // Background level offset
-    double offset = 8;
+    double offset = 9;
     // Solver of the linear least squares system in the fitting
-    FittingSolverType solver = 9;
+    FittingSolverType solver = 10;
 }
 
 // FITTING_RESPONSE:

--- a/request/fitting_request.proto
+++ b/request/fitting_request.proto
@@ -21,14 +21,12 @@ message FittingRequest {
     RegionInfo fov_info = 5;
     // Whether to create a model image of the fitting result
     bool create_model_image = 6;
-    // Whether to create a beam deconvolved model image from the fitting result
-    bool create_decon_model_image = 7;
     // Whether to create a residual image of the fitting result
-    bool create_residual_image = 8;
+    bool create_residual_image = 7;
     // Background level offset
-    double offset = 9;
+    double offset = 8;
     // Solver of the linear least squares system in the fitting
-    FittingSolverType solver = 10;
+    FittingSolverType solver = 9;
 }
 
 // FITTING_RESPONSE:


### PR DESCRIPTION
It supports both the backend [PR 1364](https://github.com/CARTAvis/carta-backend/pull/1364) and frontend [PR 2368](https://github.com/CARTAvis/carta-frontend/pull/2368).