### PR TITLE
Add overwrite field to SaveFile, ExportRegion

### DIFF
--- a/control/export_region.proto
+++ b/control/export_region.proto
@@ -21,6 +21,8 @@ message ExportRegion {
     string directory = 5;
     // Optional file name of server file
     string file = 6;
+    // Optional overwrite existing file
+    bool overwrite = 7;
 }
 
 // EXPORT_REGION_ACK

--- a/control/export_region.proto
+++ b/control/export_region.proto
@@ -34,4 +34,6 @@ message ExportRegionAck {
     string message = 2;
     // File contents for client export (one line per string)
     repeated string contents = 3;
+    // Request for overwrite confirmation
+    bool overwrite_confirmation_required = 4;
 }

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -220,8 +220,8 @@ Changelog
      - 27/10/23
      - Adjusted file ID generation.
    * - ``29.0.0``
-     - 23/05/24
-     - Added ``overwrite`` to :carta:ref:`SaveFile` message.
+     - 26/06/24
+     - Added ``overwrite`` to :carta:ref:`SaveFile` and :carta:ref:`ExportRegion` messages.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -219,6 +219,9 @@ Changelog
    * - ``28.14.0``
      - 27/10/23
      - Adjusted file ID generation.
+   * - ``29.0.0``
+     - 23/05/24
+     - Added ``overwrite`` to :carta:ref:`SaveFile` message.
 
 Versioning
 ----------

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,11 +1,11 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 14 August 2023
+:Date: 11 June 2024
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 28.14.0
-:ICD Version Integer: 28
-:CARTA Target: Version 4.0
+:Version: 29.0.0
+:ICD Version Integer: 29
+:CARTA Target: Version 5.0
 
 .. include:: changelog.rst.txt
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -695,6 +695,10 @@ Response for :carta:refc:`EXPORT_REGION` to indicate success and file contents i
      - string
      - repeated
      - File contents for client export (one line per string)
+   * - overwrite_confirmation_required
+     - bool
+     - 
+     - Request for overwrite confirmation
 
 .. carta:class:: carta-f2b fileinforequest
 
@@ -2295,6 +2299,10 @@ Source file: `request/save_file.proto <https://github.com/CARTAvis/carta-protobu
      - string
      - 
      - 
+   * - overwrite_confirmation_required
+     - bool
+     - 
+     - Request for overwrite confirmation
 
 .. carta:class:: carta-f2b scriptingrequest
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1692,10 +1692,6 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - sfixed32
      - 
      - The ID of the sync sequence
-   * - tile_count
-     - sfixed32
-     - 
-     - The number of tiles in a sync group
    * - animation_id
      - sfixed32
      - 
@@ -1745,6 +1741,10 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - sfixed32
      - 
      - The ID of the animation (if any)
+   * - tile_count
+     - sfixed32
+     - 
+     - The number of tiles in a sync group
    * - end_sync
      - bool
      - 
@@ -2254,6 +2254,10 @@ Source file: `request/save_file.proto <https://github.com/CARTAvis/carta-protobu
      - double
      - 
      - Set the rest frequency (Hz) of the image
+   * - overwrite
+     - bool
+     - 
+     - Overwrite existing image
 
 .. carta:class:: carta-f2b savefileack
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -657,6 +657,10 @@ Backend responds with  :carta:refc:`EXPORT_REGION_ACK`
      - string
      - 
      - Optional file name of server file
+   * - overwrite
+     - bool
+     - 
+     - Optional overwrite existing file
 
 .. carta:class:: carta-b2f exportregionack
 

--- a/request/save_file.proto
+++ b/request/save_file.proto
@@ -17,6 +17,8 @@ message SaveFile {
     bool keep_degenerate = 8;
     // Set the rest frequency (Hz) of the image
     double rest_freq = 9;
+    // Overwrite existing image
+    bool overwrite = 10;
 }
 
 message SaveFileAck {

--- a/request/save_file.proto
+++ b/request/save_file.proto
@@ -25,4 +25,6 @@ message SaveFileAck {
     sfixed32 file_id = 1;
     bool success = 2;
     string message = 3;
+    // Request for overwrite confirmation
+    bool overwrite_confirmation_required = 4;
 }


### PR DESCRIPTION
To prevent accidental overwrite of existing image, directory, or file, add overwrite flag to SaveFile and ExportRegion.