### PR TITLE
Add rest frequency to moment request

### DIFF
--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -226,7 +226,7 @@ Changelog
      - 26/06/24
      - Added ``overwrite`` to :carta:ref:`SaveFile` and :carta:ref:`ExportRegion` messages.
    * - ``29.1.0``
-     - 23/07/24
+     - 27/08/24
      - Added ``rest_freq`` to :carta:ref:`MomentRequest` message.
 
 Versioning

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -219,6 +219,9 @@ Changelog
    * - ``28.14.0``
      - 27/10/23
      - Adjusted file ID generation.
+   * - ``28.15.0``
+     - 23/07/24
+     - Added ``rest_freq`` to :carta:ref:`MomentRequest` message.
 
 Versioning
 ----------

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,7 +1,7 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 9 September 2024
+:Date: 27 August 2024
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
 :Version: 29.1.0
 :ICD Version Integer: 29

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,9 +1,9 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 11 June 2024
+:Date: 9 September 2024
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 29.0.0
+:Version: 29.1.0
 :ICD Version Integer: 29
 :CARTA Target: Version 5.0
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1239,6 +1239,10 @@ Source file: `request/moment_request.proto <https://github.com/CARTAvis/carta-pr
      - bool
      - 
      - 
+   * - rest_freq
+     - double
+     - 
+     - 
 
 .. carta:class:: carta-b2f momentresponse
 
@@ -1692,10 +1696,6 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - sfixed32
      - 
      - The ID of the sync sequence
-   * - tile_count
-     - sfixed32
-     - 
-     - The number of tiles in a sync group
    * - animation_id
      - sfixed32
      - 
@@ -1745,6 +1745,10 @@ Source file: `stream/raster_tile.proto <https://github.com/CARTAvis/carta-protob
      - sfixed32
      - 
      - The ID of the animation (if any)
+   * - tile_count
+     - sfixed32
+     - 
+     - The number of tiles in a sync group
    * - end_sync
      - bool
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -1242,7 +1242,7 @@ Source file: `request/moment_request.proto <https://github.com/CARTAvis/carta-pr
    * - rest_freq
      - double
      - 
-     - 
+     - Set the rest frequency (Hz) of the image
 
 .. carta:class:: carta-b2f momentresponse
 

--- a/request/moment_request.proto
+++ b/request/moment_request.proto
@@ -14,6 +14,7 @@ message MomentRequest {
     MomentMask mask = 6;
     FloatBounds pixel_range = 7;
     bool keep = 8;
+    // Set the rest frequency (Hz) of the image
     double rest_freq = 9;
 }
 

--- a/request/moment_request.proto
+++ b/request/moment_request.proto
@@ -14,6 +14,7 @@ message MomentRequest {
     MomentMask mask = 6;
     FloatBounds pixel_range = 7;
     bool keep = 8;
+    double rest_freq = 9;
 }
 
 message MomentResponse {


### PR DESCRIPTION
Added rest_freq field to MomentRequest to apply a rest frequency to the image before creating moments.

Advance protobuf minor version.