### PR TITLE
update description of FILE_LIST_REQUEST

### DIFF
--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -233,7 +233,7 @@ Changelog
      - Added optional ``channel_range`` and ``current_range`` to :carta:ref:`SetImageChannels` message, optional ``current_tiles`` to :carta:ref:`AddRequiredTiles` message, and new message :carta:ref:`ChannelMapFlowControl` to support channel map view.
    * - ``30.0.1``
      - 18/06/25
-     - Modified descriptions of :carta:refc:`FILE_LIST_RESPONSE`, :carta:refc:`FileInfo`, and :carta:refc:`DirectoryInfo` for addressing the new behavior of the All Files mode.
+     - Modified descriptions of :carta:refc:`FileListResponse`, :carta:refc:`FileInfo`, and :carta:refc:`DirectoryInfo` for addressing the new behavior of "AllFiles" mode.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -233,7 +233,7 @@ Changelog
      - Added optional ``channel_range`` and ``current_range`` to :carta:ref:`SetImageChannels` message, optional ``current_tiles`` to :carta:ref:`AddRequiredTiles` message, and new message :carta:ref:`ChannelMapFlowControl` to support channel map view.
    * - ``30.0.1``
      - 18/06/25
-     - Modified descriptions of :carta:FileListRequest, :carta:FileListRequest:`FileInfo`, and :carta:FileListRequest:`DirectoryInfo` for addressing new behavior of the All Files mode.
+     - Modified descriptions of :carta:refc:`FILE_LIST_RESPONSE`, :carta:refc:`FileInfo`, and :carta:refc:`DirectoryInfo` for addressing the new behavior of the All Files mode.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -231,6 +231,9 @@ Changelog
    * - ``30.0.0``
      - 23/10/24
      - Added optional ``channel_range`` and ``current_range`` to :carta:ref:`SetImageChannels` message, optional ``current_tiles`` to :carta:ref:`AddRequiredTiles` message, and new message :carta:ref:`ChannelMapFlowControl` to support channel map view.
+   * - ``30.0.1``
+     - 18/06/25
+     - Modified descriptions of :carta:FileListRequest, :carta:FileListRequest:`FileInfo`, and :carta:FileListRequest:`DirectoryInfo` for addressing new behavior of the All Files mode.
 
 Versioning
 ----------

--- a/docs/src/changelog.rst.txt
+++ b/docs/src/changelog.rst.txt
@@ -233,7 +233,7 @@ Changelog
      - Added optional ``channel_range`` and ``current_range`` to :carta:ref:`SetImageChannels` message, optional ``current_tiles`` to :carta:ref:`AddRequiredTiles` message, and new message :carta:ref:`ChannelMapFlowControl` to support channel map view.
    * - ``30.0.1``
      - 18/06/25
-     - Modified descriptions of :carta:refc:`FileListResponse`, :carta:refc:`FileInfo`, and :carta:refc:`DirectoryInfo` for addressing the new behavior of "AllFiles" mode.
+     - Modified descriptions of :carta:refc:`FileListResponse`, :carta:refc:`FileInfo`, and :carta:refc:`DirectoryInfo` for addressing the new behavior of AllFiles mode.
 
 Versioning
 ----------

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -368,7 +368,7 @@ DirectoryInfo
 
 Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
 
-Directory info message structure (internal use only), sub-message of :carta:refc:`FileListResponse`
+Directory info message structure, sub-message of :carta:refc:`FileListResponse`
 
 .. list-table::
    :widths: 20 20 20 40
@@ -386,7 +386,7 @@ Directory info message structure (internal use only), sub-message of :carta:refc
    * - item_count
      - sfixed32
      - 
-     - Item number in the directory. This will be blank if :carta:refc:`FileListFilterMode` set to be "AllFiles"
+     - Number of items in the directory. This field is always unused (and left as zero) if :carta:refc:`FileListFilterMode` is AllFiles.
    * - date
      - sfixed64
      - 
@@ -459,7 +459,7 @@ FileInfo
 
 Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
 
-File info message structure (internal use only), sub-message of :carta:refc:`FileListResponse`
+File info message structure, sub-message of :carta:refc:`FileListResponse`
 
 .. list-table::
    :widths: 20 20 20 40
@@ -477,7 +477,7 @@ File info message structure (internal use only), sub-message of :carta:refc:`Fil
    * - type
      - :carta:refc:`FileType`
      - 
-     - File type. This will be blank or "Unknown" before clicking the file if :carta:refc:`FileListFilterMode` set to be "AllFiles"
+     - File type. This field may be unused (and set to UNKNOWN) if :carta:refc:`FileListFilterMode` is AllFiles
    * - size
      - sfixed64
      - 

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -368,7 +368,7 @@ DirectoryInfo
 
 Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
 
-Directory info message structure (internal use only)
+Directory info message structure (internal use only), sub-message of :carta:refc:`FileListResponse`
 
 .. list-table::
    :widths: 20 20 20 40
@@ -459,7 +459,7 @@ FileInfo
 
 Source file: `shared/defs.proto <https://github.com/CARTAvis/carta-protobuf/blob/dev/shared/defs.proto>`_
 
-File info message structure (internal use only)
+File info message structure (internal use only), sub-message of :carta:refc:`FileListResponse`
 
 .. list-table::
    :widths: 20 20 20 40

--- a/docs/src/defs.rst.txt
+++ b/docs/src/defs.rst.txt
@@ -382,15 +382,15 @@ Directory info message structure (internal use only)
    * - name
      - string
      - 
-     - 
+     - Directory name
    * - item_count
      - sfixed32
      - 
-     - 
+     - Item number in the directory. This will be blank if :carta:refc:`FileListFilterMode` set to be "AllFiles"
    * - date
      - sfixed64
      - 
-     - 
+     - Modification date
 
 .. carta:class:: carta-sub doublebounds
 
@@ -473,23 +473,23 @@ File info message structure (internal use only)
    * - name
      - string
      - 
-     - 
+     - File name
    * - type
      - :carta:refc:`FileType`
      - 
-     - 
+     - File type. This will be blank or "Unknown" before clicking the file if :carta:refc:`FileListFilterMode` set to be "AllFiles"
    * - size
      - sfixed64
      - 
-     - 
+     - File size
    * - HDU_list
      - string
      - repeated
-     - 
+     - HDU list
    * - date
      - sfixed64
      - 
-     - 
+     - Modification date
 
 .. carta:class:: carta-sub fileinfoextended
 

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,9 +1,9 @@
 CARTA Interface Control Document
 ================================
 
-:Date: 23 October 2024
+:Date: 18 June 2025
 :Authors: Angus Comrie, Rob Simmonds and the CARTA development team
-:Version: 30.0.0
+:Version: 30.0.1
 :ICD Version Integer: 30 
 :CARTA Target: Version 5.0
 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -854,7 +854,7 @@ Source file: `request/file_list.proto <https://github.com/CARTAvis/carta-protobu
 
 FILE_LIST_RESPONSE
 Response for :carta:refc:`FILE_LIST_REQUEST`.
-Gives a list of available files, as well as subdirectories. If :carta:refc:`FileListFilterMode` is set to "AllFiles", the file types of files and the item number of subdirectories will not be included, and CASA files will be treated as subdirectories. If :carta:refc:`FileListFilterMode` is set to "AllFiles" and the requested directory is a CASA file, the list of files will contain only the file itself, and the list of subdirectories will be empty.
+Gives a list of available files, as well as subdirectories. If :carta:refc:`FileListFilterMode` is set to AllFiles, the file types of files and the item number of subdirectories will not be included, and CASA files will be treated as subdirectories. If :carta:refc:`FileListFilterMode` is set to AllFiles and the requested directory is a CASA file, the list of files will contain only the file itself, and the list of subdirectories will be empty.
 
 .. list-table::
    :widths: 20 20 20 40
@@ -884,11 +884,11 @@ Gives a list of available files, as well as subdirectories. If :carta:refc:`File
    * - files
      - :carta:refc:`FileInfo`
      - repeated
-     - List of available image files with sizes and modification dates. If :carta:refc:`FileListFilterMode` is not "AllFiles", file types are also included.
+     - List of available image files with sizes and modification dates. File types are included if :carta:refc:`FileListFilterMode` is not AllFiles, or if the requested directory in AllFiles mode is a single CASA file.
    * - subdirectories
      - :carta:refc:`DirectoryInfo`
      - repeated
-     - List of subdirectories with modification dates. If :carta:refc:`FileListFilterMode` is not "AllFiles", item counts are also included.
+     - List of subdirectories with modification dates. If :carta:refc:`FileListFilterMode` is not AllFiles, item counts are also included.
    * - cancel
      - bool
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -854,11 +854,7 @@ Source file: `request/file_list.proto <https://github.com/CARTAvis/carta-protobu
 
 FILE_LIST_RESPONSE
 Response for :carta:refc:`FILE_LIST_REQUEST`.
-If :carta:refc:`FileListFilterMode` is NOT "AllFiles", 
-gives a list of available files (and their types), as well as subdirectories.
-If :carta:refc:`FileListFilterMode` is "AllFiles", 
-:carta:refc:`FileInfo` and :carta:refc:`DirectoryInfo` just sends a list of available files and subdirectories,
-and file type will be sent when requested.
+Gives a list of available files, as well as subdirectories. If :carta:refc:`FileListFilterMode` is set to "AllFiles", the file types of files and the item number of subdirectories will not be included, and CASA files will be treated as subdirectories. If :carta:refc:`FileListFilterMode` is set to "AllFiles" and the requested directory is a CASA file, the list of files will contain only the file itself, and the list of subdirectories will be empty.
 
 .. list-table::
    :widths: 20 20 20 40
@@ -888,11 +884,11 @@ and file type will be sent when requested.
    * - files
      - :carta:refc:`FileInfo`
      - repeated
-     - If :carta:refc:`FileListFilterMode` is NOT "All": List of available image files, with file type information and size information. If :carta:refc:`FileListFilterMode` is "All": List of available image files. Other information when request.
+     - If :carta:refc:`FileListFilterMode` is NOT "AllFiles": List of available image files with file type, size, and modified date information.   If :carta:refc:`FileListFilterMode` is "AllFiles": List of available image files with size and modified date information. Type information are sent when requested.
    * - subdirectories
      - :carta:refc:`DirectoryInfo`
      - repeated
-     - If :carta:refc:`FileListFilterMode` is NOT "All": List of available subdirectories, with number of items and modified date. If :carta:refc:`FileListFilterMode` is "All": List of available subdirectories.
+     - If :carta:refc:`FileListFilterMode` is NOT "AllFiles": List of subdirectories, with number of items and modified date.   If :carta:refc:`FileListFilterMode` is "AllFiles": List of subdirectories, with modified date.
    * - cancel
      - bool
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -884,11 +884,11 @@ Gives a list of available files, as well as subdirectories. If :carta:refc:`File
    * - files
      - :carta:refc:`FileInfo`
      - repeated
-     - If :carta:refc:`FileListFilterMode` is NOT "AllFiles": List of available image files with file type, size, and modified date information.   If :carta:refc:`FileListFilterMode` is "AllFiles": List of available image files with size and modified date information. Type information are sent when requested.
+     - List of available image files with sizes and modification dates. If :carta:refc:`FileListFilterMode` is not "AllFiles", file types are also included.
    * - subdirectories
      - :carta:refc:`DirectoryInfo`
      - repeated
-     - If :carta:refc:`FileListFilterMode` is NOT "AllFiles": List of subdirectories, with number of items and modified date.   If :carta:refc:`FileListFilterMode` is "AllFiles": List of subdirectories, with modified date.
+     - List of subdirectories with modification dates. If :carta:refc:`FileListFilterMode` is not "AllFiles", item counts are also included.
    * - cancel
      - bool
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -854,7 +854,11 @@ Source file: `request/file_list.proto <https://github.com/CARTAvis/carta-protobu
 
 FILE_LIST_RESPONSE
 Response for :carta:refc:`FILE_LIST_REQUEST`.
-Gives a list of available files (and their types), as well as subdirectories
+If :carta:refc:`FileListFilterMode` is NOT "All", 
+gives a list of available files (and their types), as well as subdirectories.
+If :carta:refc:`FileListFilterMode` is "All", 
+:carta:refc:`FileInfo` and :carta:refc:`DirectoryInfo` just sends a list of available files and subdirectories,
+and file type will be sent when request.
 
 .. list-table::
    :widths: 20 20 20 40
@@ -884,11 +888,11 @@ Gives a list of available files (and their types), as well as subdirectories
    * - files
      - :carta:refc:`FileInfo`
      - repeated
-     - List of available image files, with file type information and size information.
+     - If :carta:refc:`FileListFilterMode` is NOT "All": List of available image files, with file type information and size information. If :carta:refc:`FileListFilterMode` is "All": List of available image files. Other information when request.
    * - subdirectories
      - :carta:refc:`DirectoryInfo`
      - repeated
-     - List of available subdirectories, with number of items and modified date
+     - If :carta:refc:`FileListFilterMode` is NOT "All": List of available subdirectories, with number of items and modified date. If :carta:refc:`FileListFilterMode` is "All": List of available subdirectories.
    * - cancel
      - bool
      - 

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -854,11 +854,11 @@ Source file: `request/file_list.proto <https://github.com/CARTAvis/carta-protobu
 
 FILE_LIST_RESPONSE
 Response for :carta:refc:`FILE_LIST_REQUEST`.
-If :carta:refc:`FileListFilterMode` is NOT "All", 
+If :carta:refc:`FileListFilterMode` is NOT "AllFiles", 
 gives a list of available files (and their types), as well as subdirectories.
-If :carta:refc:`FileListFilterMode` is "All", 
+If :carta:refc:`FileListFilterMode` is "AllFiles", 
 :carta:refc:`FileInfo` and :carta:refc:`DirectoryInfo` just sends a list of available files and subdirectories,
-and file type will be sent when request.
+and file type will be sent when requested.
 
 .. list-table::
    :widths: 20 20 20 40

--- a/docs/src/messages.rst.txt
+++ b/docs/src/messages.rst.txt
@@ -854,7 +854,7 @@ Source file: `request/file_list.proto <https://github.com/CARTAvis/carta-protobu
 
 FILE_LIST_RESPONSE
 Response for :carta:refc:`FILE_LIST_REQUEST`.
-Gives a list of available files, as well as subdirectories. If :carta:refc:`FileListFilterMode` is set to AllFiles, the file types of files and the item number of subdirectories will not be included, and CASA files will be treated as subdirectories. If :carta:refc:`FileListFilterMode` is set to AllFiles and the requested directory is a CASA file, the list of files will contain only the file itself, and the list of subdirectories will be empty.
+Gives a list of available files, as well as subdirectories. If :carta:refc:`FileListFilterMode` is set to AllFiles, the file types of files and the item counts of subdirectories will not be included, and CASA files will be treated as subdirectories. If :carta:refc:`FileListFilterMode` is set to AllFiles and the requested directory is a CASA file, the list of files will contain only the file itself, and the list of subdirectories will be empty.
 
 .. list-table::
    :widths: 20 20 20 40

--- a/request/file_list.proto
+++ b/request/file_list.proto
@@ -16,7 +16,11 @@ message FileListRequest {
 
 // FILE_LIST_RESPONSE
 // Response for FILE_LIST_REQUEST.
-// Gives a list of available files (and their types), as well as subdirectories
+// If FileListFilterMode is NOT "All", 
+// gives a list of available files (and their types), as well as subdirectories.
+// If FileListFilterMode is "All", 
+// FileInfo and DirectoryInfo just sends a list of available files and subdirectories,
+// and file type will be sent when request. 
 message FileListResponse {
     // Defines whether the FILE_LIST_REQUEST was successful
     bool success = 1;
@@ -26,9 +30,11 @@ message FileListResponse {
     string directory = 3;
     // Directory parent (null/empty if top-level)
     string parent = 4;
-    // List of available image files, with file type information and size information.
+    // If FileListFilterMode is NOT "All": List of available image files, with file type information and size information.
+    // If FileListFilterMode is "All": List of available image files. Other information when request.
     repeated FileInfo files = 5;
-    // List of available subdirectories, with number of items and modified date
+    // If FileListFilterMode is NOT "All": List of available subdirectories, with number of items and modified date.
+    // If FileListFilterMode is "All": List of available subdirectories.
     repeated DirectoryInfo subdirectories = 6;
     bool cancel = 7;
 }

--- a/request/file_list.proto
+++ b/request/file_list.proto
@@ -16,7 +16,7 @@ message FileListRequest {
 
 // FILE_LIST_RESPONSE
 // Response for FILE_LIST_REQUEST.
-// Gives a list of available files, as well as subdirectories. If FileListFilterMode is set to "AllFiles", the file types of files and the item number of subdirectories will not be included, and CASA files will be treated as subdirectories. If FileListFilterMode is set to "AllFiles" and the requested directory is a CASA file, the list of files will contain only the file itself, and the list of subdirectories will be empty.
+// Gives a list of available files, as well as subdirectories. If FileListFilterMode is set to AllFiles, the file types of files and the item number of subdirectories will not be included, and CASA files will be treated as subdirectories. If FileListFilterMode is set to AllFiles and the requested directory is a CASA file, the list of files will contain only the file itself, and the list of subdirectories will be empty.
 message FileListResponse {
     // Defines whether the FILE_LIST_REQUEST was successful
     bool success = 1;
@@ -26,9 +26,9 @@ message FileListResponse {
     string directory = 3;
     // Directory parent (null/empty if top-level)
     string parent = 4;
-    // List of available image files with sizes and modification dates. If FileListFilterMode is not "AllFiles", file types are also included. 
+    // List of available image files with sizes and modification dates. File types are included if FileListFilterMode is not AllFiles, or if the requested directory in AllFiles mode is a single CASA file.
     repeated FileInfo files = 5;
-    // List of subdirectories with modification dates. If FileListFilterMode is not "AllFiles", item counts are also included.
+    // List of subdirectories with modification dates. If FileListFilterMode is not AllFiles, item counts are also included.
     repeated DirectoryInfo subdirectories = 6;
     bool cancel = 7;
 }

--- a/request/file_list.proto
+++ b/request/file_list.proto
@@ -16,7 +16,7 @@ message FileListRequest {
 
 // FILE_LIST_RESPONSE
 // Response for FILE_LIST_REQUEST.
-// Gives a list of available files, as well as subdirectories. If FileListFilterMode is set to AllFiles, the file types of files and the item number of subdirectories will not be included, and CASA files will be treated as subdirectories. If FileListFilterMode is set to AllFiles and the requested directory is a CASA file, the list of files will contain only the file itself, and the list of subdirectories will be empty.
+// Gives a list of available files, as well as subdirectories. If FileListFilterMode is set to AllFiles, the file types of files and the item counts of subdirectories will not be included, and CASA files will be treated as subdirectories. If FileListFilterMode is set to AllFiles and the requested directory is a CASA file, the list of files will contain only the file itself, and the list of subdirectories will be empty.
 message FileListResponse {
     // Defines whether the FILE_LIST_REQUEST was successful
     bool success = 1;

--- a/request/file_list.proto
+++ b/request/file_list.proto
@@ -16,11 +16,7 @@ message FileListRequest {
 
 // FILE_LIST_RESPONSE
 // Response for FILE_LIST_REQUEST.
-// If FileListFilterMode is NOT "All", 
-// gives a list of available files (and their types), as well as subdirectories.
-// If FileListFilterMode is "All", 
-// FileInfo and DirectoryInfo just sends a list of available files and subdirectories,
-// and file type will be sent when request. 
+Gives a list of available files, as well as subdirectories. If FileListFilterMode is set to "AllFiles", the file types of files and the item number of subdirectories will not be included, and CASA files will be treated as subdirectories. If FileListFilterMode is set to "AllFiles" and the requested directory is a CASA file, the list of files will contain only the file itself, and the list of subdirectories will be empty.
 message FileListResponse {
     // Defines whether the FILE_LIST_REQUEST was successful
     bool success = 1;
@@ -30,11 +26,11 @@ message FileListResponse {
     string directory = 3;
     // Directory parent (null/empty if top-level)
     string parent = 4;
-    // If FileListFilterMode is NOT "All": List of available image files, with file type information and size information.
-    // If FileListFilterMode is "All": List of available image files. Other information when request.
+    // If FileListFilterMode is NOT "AllFiles": List of available image files with file type and size information.
+    // If FileListFilterMode is "AllFiles": List of available image files. File size and type information are sent when requested.
     repeated FileInfo files = 5;
-    // If FileListFilterMode is NOT "All": List of available subdirectories, with number of items and modified date.
-    // If FileListFilterMode is "All": List of available subdirectories.
+    // If FileListFilterMode is NOT "AllFiles": List of subdirectories including item number in these subdirectories.
+    // If FileListFilterMode is "AllFiles": List of subdirectories with modified data.
     repeated DirectoryInfo subdirectories = 6;
     bool cancel = 7;
 }

--- a/request/file_list.proto
+++ b/request/file_list.proto
@@ -26,11 +26,11 @@ message FileListResponse {
     string directory = 3;
     // Directory parent (null/empty if top-level)
     string parent = 4;
-    // If FileListFilterMode is NOT "AllFiles": List of available image files with file type and size information.
-    // If FileListFilterMode is "AllFiles": List of available image files. File size and type information are sent when requested.
+    // If FileListFilterMode is NOT "AllFiles": List of available image files with file type, size, and modified date information.  
+    // If FileListFilterMode is "AllFiles": List of available image files with size and modified date information. Type information are sent when requested.  
     repeated FileInfo files = 5;
-    // If FileListFilterMode is NOT "AllFiles": List of subdirectories including item number in these subdirectories.
-    // If FileListFilterMode is "AllFiles": List of subdirectories with modified data.
+    // If FileListFilterMode is NOT "AllFiles": List of subdirectories, with number of items and modified date.  
+    // If FileListFilterMode is "AllFiles": List of subdirectories, with modified date.  
     repeated DirectoryInfo subdirectories = 6;
     bool cancel = 7;
 }

--- a/request/file_list.proto
+++ b/request/file_list.proto
@@ -16,7 +16,7 @@ message FileListRequest {
 
 // FILE_LIST_RESPONSE
 // Response for FILE_LIST_REQUEST.
-Gives a list of available files, as well as subdirectories. If FileListFilterMode is set to "AllFiles", the file types of files and the item number of subdirectories will not be included, and CASA files will be treated as subdirectories. If FileListFilterMode is set to "AllFiles" and the requested directory is a CASA file, the list of files will contain only the file itself, and the list of subdirectories will be empty.
+// Gives a list of available files, as well as subdirectories. If FileListFilterMode is set to "AllFiles", the file types of files and the item number of subdirectories will not be included, and CASA files will be treated as subdirectories. If FileListFilterMode is set to "AllFiles" and the requested directory is a CASA file, the list of files will contain only the file itself, and the list of subdirectories will be empty.
 message FileListResponse {
     // Defines whether the FILE_LIST_REQUEST was successful
     bool success = 1;

--- a/request/file_list.proto
+++ b/request/file_list.proto
@@ -26,11 +26,9 @@ message FileListResponse {
     string directory = 3;
     // Directory parent (null/empty if top-level)
     string parent = 4;
-    // If FileListFilterMode is NOT "AllFiles": List of available image files with file type, size, and modified date information.  
-    // If FileListFilterMode is "AllFiles": List of available image files with size and modified date information. Type information are sent when requested.  
+    // List of available image files with sizes and modification dates. If FileListFilterMode is not "AllFiles", file types are also included. 
     repeated FileInfo files = 5;
-    // If FileListFilterMode is NOT "AllFiles": List of subdirectories, with number of items and modified date.  
-    // If FileListFilterMode is "AllFiles": List of subdirectories, with modified date.  
+    // List of subdirectories with modification dates. If FileListFilterMode is not "AllFiles", item counts are also included.
     repeated DirectoryInfo subdirectories = 6;
     bool cancel = 7;
 }

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -17,11 +17,11 @@ message DoublePoint {
     double y = 2;
 }
 
-// File info message structure (internal use only), submessage of FileListResponse
+// File info message structure, sub-message of FileListResponse
 message FileInfo {
     // File name
     string name = 1;
-    // File type. This will be blank or "Unknown" before clicking the file if FileListFilterMode set to be "AllFiles"
+    // File type. This field may be unused (and set to UNKNOWN) if FileListFilterMode is AllFiles
     FileType type = 2;
     // File size
     sfixed64 size = 3;
@@ -31,11 +31,11 @@ message FileInfo {
     sfixed64 date = 5;
 }
 
-// Directory info message structure (internal use only), submessage of FileListResponse
+// Directory info message structure, sub-message of FileListResponse
 message DirectoryInfo {
     // Directory name
     string name = 1;
-    // Item number in the directory. This will be blank if FileListFilterMode set to be "AllFiles"
+    // Number of items in the directory. This field is always unused (and left as zero) if FileListFilterMode is AllFiles.
     sfixed32 item_count = 2;
     // Modification date
     sfixed64 date = 3;

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -19,17 +19,25 @@ message DoublePoint {
 
 // File info message structure (internal use only)
 message FileInfo {
+    // File name
     string name = 1;
+    // File type. This will be blank or "Unknown" before clicking the file if FileListFilterMode set to be "AllFiles"
     FileType type = 2;
+    // File size
     sfixed64 size = 3;
+    // HDU list
     repeated string HDU_list = 4;
+    // Modification date
     sfixed64 date = 5;
 }
 
 // Directory info message structure (internal use only)
 message DirectoryInfo {
+    // Directory name
     string name = 1;
+    // Item number in the directory. This will be blank if FileListFilterMode set to be "AllFiles"
     sfixed32 item_count = 2;
+    // Modification date
     sfixed64 date = 3;
 }
 

--- a/shared/defs.proto
+++ b/shared/defs.proto
@@ -17,7 +17,7 @@ message DoublePoint {
     double y = 2;
 }
 
-// File info message structure (internal use only)
+// File info message structure (internal use only), submessage of FileListResponse
 message FileInfo {
     // File name
     string name = 1;
@@ -31,7 +31,7 @@ message FileInfo {
     sfixed64 date = 5;
 }
 
-// Directory info message structure (internal use only)
+// Directory info message structure (internal use only), submessage of FileListResponse
 message DirectoryInfo {
     // Directory name
     string name = 1;


### PR DESCRIPTION
This PR is for the frontend [PR2525](https://github.com/CARTAvis/carta-frontend/pull/2525) and backend [PR1436](https://github.com/CARTAvis/carta-backend/pull/1436). In this PR, we expand the description of `FileListResponse`, `FileInfo`, and `DirectoryInfo` for the new behavior of the "AllFiles" mode. 