### PR TITLE
vector overlay updating after session resume 

### DIFF
--- a/control/resume_session.proto
+++ b/control/resume_session.proto
@@ -6,6 +6,7 @@ import "enums.proto";
 import "open_catalog_file.proto";
 import "contour.proto";
 import "concat_stokes_files.proto";
+import "vector_overlay.proto";
 
 message ImageProperties {
     string directory = 1;
@@ -20,6 +21,7 @@ message ImageProperties {
     SetContourParameters contour_settings = 10;
     repeated StokesFile stokes_files = 11;
     bool support_aips_beam = 12;
+    SetVectorOverlayParameters vector_overlay_settings = 13;
 }
 
 message ResumeSession {

--- a/docs/src/changelog.rst
+++ b/docs/src/changelog.rst
@@ -9,7 +9,22 @@ Versioning information
 * Patch (``1.2.3`` -> ``1.2.4``): this is a change which does not affect functionality (e.g. a typo fix in a comment, or a changed field name).
 
 Some legacy changelog entries may not follow this approach. Only changes to the protocol buffer source files should be recorded here; changes only to this documentation do not require a version bump.
-   
+
+CARTA version 6
+~~~~~~~~~~~~~~~
+
+.. list-table::
+   :widths: 15 15 70
+   :header-rows: 1
+   :class: changelog
+
+   * - Version
+     - Date
+     - Description
+   * - ``30.2.0``
+     - 08/12/25
+     - Added ``vector_overlay_settings`` to :carta:ref:`ImageProperties` message to update vector overlay after session resume.
+
 CARTA version 5
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Adding a vector overlay setting to `ImageProperties` to support vector overlay updating after session resume. 
The companion PRs are backend [PR1544](https://github.com/CARTAvis/carta-backend/pull/1544) and [fronded PR2636](https://github.com/CARTAvis/carta-frontend/pull/2636). 