### PR TITLE
channel map refactoring

### DIFF
--- a/control/channel_map.proto
+++ b/control/channel_map.proto
@@ -2,10 +2,21 @@ syntax = "proto3";
 package CARTA;
 
 // CHANNEL_MAP_FLOW_CONTROL
-// Used for informing the frontend that all data for a channel has been sent
+// Reports the outcome after the backend processes a channel map request
 message ChannelMapFlowControl {
+    enum Status {
+        STATUS_UNSPECIFIED = 0;
+        COMPLETED = 1;
+        REJECTED = 2;
+        CANCELLED = 3;
+    }
+
     // The file ID that the channel map view corresponds to
     sfixed32 file_id = 1;
     // The completed channel
-    sfixed32 received_channel = 2;
+    sfixed32 completed_channel = 2;
+    // The outcome of the channel map request
+    Status status = 3;
+    // An optional explanation when the request was not completed
+    string message = 4;
 }

--- a/control/channel_map.proto
+++ b/control/channel_map.proto
@@ -2,10 +2,10 @@ syntax = "proto3";
 package CARTA;
 
 // CHANNEL_MAP_FLOW_CONTROL
-// Used for informing the backend of which frames have been received
+// Used for informing the frontend that all data for a channel has been sent
 message ChannelMapFlowControl {
     // The file ID that the channel map view corresponds to
     sfixed32 file_id = 1;
-    // The latest flow control channel received
+    // The completed channel
     sfixed32 received_channel = 2;
 }

--- a/control/set_image_channels.proto
+++ b/control/set_image_channels.proto
@@ -17,4 +17,8 @@ message SetImageChannels {
     reserved 5, 6;
     // Set current image channel during channel map
     bool channel_map_enabled = 7;
+    // The next image channel to prepare while sending the current channel map tiles
+    optional sfixed32 next_channel = 8;
+    // Required tiles to prepare for the next image channel
+    AddRequiredTiles next_required_tiles = 9;
 }

--- a/control/set_image_channels.proto
+++ b/control/set_image_channels.proto
@@ -1,7 +1,6 @@
 syntax = "proto3";
 package CARTA;
 
-import "defs.proto";
 import "tiles.proto";
 
 // SET_IMAGE_CHANNELS
@@ -15,10 +14,7 @@ message SetImageChannels {
     sfixed32 stokes = 3;
     // Required tiles when changing channels
     AddRequiredTiles required_tiles = 4;
-    // Optional requested channels for channel map view
-    IntBounds channel_range = 5;
-    // Optional range of channels for channel map view
-    IntBounds current_range = 6;
+    reserved 5, 6;
     // Set current image channel during channel map
     bool channel_map_enabled = 7;
 }

--- a/control/set_image_channels.proto
+++ b/control/set_image_channels.proto
@@ -17,8 +17,4 @@ message SetImageChannels {
     reserved 5, 6;
     // Set current image channel during channel map
     bool channel_map_enabled = 7;
-    // The next image channel to prepare while sending the current channel map tiles
-    optional sfixed32 next_channel = 8;
-    // Required tiles to prepare for the next image channel
-    AddRequiredTiles next_required_tiles = 9;
 }

--- a/control/tiles.proto
+++ b/control/tiles.proto
@@ -14,8 +14,7 @@ message AddRequiredTiles {
     CompressionType compression_type = 3;
     // Compression quality switch
     float compression_quality = 4;
-    // Optional list of all tiles in channel map view
-    repeated sfixed32 current_tiles = 5;
+    reserved 5;
 }
 
 // REMOVE_REQUIRED_TILES

--- a/docs/src/changelog.rst
+++ b/docs/src/changelog.rst
@@ -21,6 +21,9 @@ CARTA version 6
    * - Version
      - Date
      - Description
+   * - ``31.0.0``
+     - 17/07/26
+     - Changed channel map requests to process one channel at a time, changed :carta:ref:`ChannelMapFlowControl` to a backend completion event, and removed the channel range cancellation fields.
    * - ``30.2.0``
      - 08/12/25
      - Added ``vector_overlay_settings`` to :carta:ref:`ImageProperties` message to update vector overlay after session resume.

--- a/docs/src/changelog.rst
+++ b/docs/src/changelog.rst
@@ -24,7 +24,6 @@ CARTA version 6
    * - ``31.0.0``
      - 20/07/26
      - Changed channel map requests to process one channel at a time, changed :carta:ref:`ChannelMapFlowControl` to a backend completion event, and removed the channel range cancellation fields.
-     - Added optional ``next_channel`` and ``next_required_tiles`` fields to :carta:ref:`SetImageChannels` for channel map tile preparation.
    * - ``30.2.0``
      - 08/12/25
      - Added ``vector_overlay_settings`` to :carta:ref:`ImageProperties` message to update vector overlay after session resume.

--- a/docs/src/changelog.rst
+++ b/docs/src/changelog.rst
@@ -21,6 +21,9 @@ CARTA version 6
    * - Version
      - Date
      - Description
+   * - ``32.0.0``
+     - 20/07/26
+     - Added optional ``next_channel`` and ``next_required_tiles`` fields to :carta:ref:`SetImageChannels` for channel map tile preparation.
    * - ``31.0.0``
      - 17/07/26
      - Changed channel map requests to process one channel at a time, changed :carta:ref:`ChannelMapFlowControl` to a backend completion event, and removed the channel range cancellation fields.

--- a/docs/src/changelog.rst
+++ b/docs/src/changelog.rst
@@ -21,12 +21,10 @@ CARTA version 6
    * - Version
      - Date
      - Description
-   * - ``32.0.0``
-     - 20/07/26
-     - Added optional ``next_channel`` and ``next_required_tiles`` fields to :carta:ref:`SetImageChannels` for channel map tile preparation.
    * - ``31.0.0``
-     - 17/07/26
+     - 20/07/26
      - Changed channel map requests to process one channel at a time, changed :carta:ref:`ChannelMapFlowControl` to a backend completion event, and removed the channel range cancellation fields.
+     - Added optional ``next_channel`` and ``next_required_tiles`` fields to :carta:ref:`SetImageChannels` for channel map tile preparation.
    * - ``30.2.0``
      - 08/12/25
      - Added ``vector_overlay_settings`` to :carta:ref:`ImageProperties` message to update vector overlay after session resume.

--- a/docs/src/changelog.rst
+++ b/docs/src/changelog.rst
@@ -23,7 +23,7 @@ CARTA version 6
      - Description
    * - ``31.0.0``
      - 20/07/26
-     - Changed channel map requests to process one channel at a time, changed :carta:ref:`ChannelMapFlowControl` to a backend completion event, and removed the channel range cancellation fields.
+     - Changed channel map requests to process one channel at a time, changed :carta:ref:`ChannelMapFlowControl` to report the completed channel and request status, and removed the channel range cancellation fields.
    * - ``30.2.0``
      - 08/12/25
      - Added ``vector_overlay_settings`` to :carta:ref:`ImageProperties` message to update vector overlay after session resume.


### PR DESCRIPTION
Closes #110. 

- Modifying the description of `channel_map.proto`
- Removing `channel_range` and `current_range` in `set_image_channels.proto`
- Removing `current_tiles` in `tiles.proto`. 
- Upgrade ICD version to 31.